### PR TITLE
Fix/api file names

### DIFF
--- a/code/API_definitions/README.MD
+++ b/code/API_definitions/README.MD
@@ -1,23 +1,29 @@
-# WebRTC API definitions
+# WebRTC APIs definitions
 
-This folder contain the OpenAPI v3 definition of the WebRTC API
+This folder contain the OpenAPI v3 definition of the WebRTC subgroup
 
 ## APIs included
 
-* [Registration and Authentication management](BYON-RACM-Service.yaml)
+* `webrtc-registration` [Registration and Authentication management](webrtc-registration.yaml)
   * This API definition provides functionality for a REST client, browser or native application to manage Registration and Connectivity (RACM) towards Internet Multimedia Subsystem (IMS) Network.
-    * [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/BYON-RACM-Service.yaml&nocors)
-    * [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/BYON-RACM-Service.yaml)
-  
-* [Notification Channel management](BYON-Notification-Channel.yaml)
-  * This API definition provides functionality for a REST client, browser or native application, to establish notification channel to receive asynchronous notifications from MNO's IMS Network.
-    * [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/BYON-Notification-Channel.yaml&nocors)
-    * [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/BYON-Notification-Channel.yaml) 
+    * [View main on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-registration.yaml&nocors)
+    * [View main on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-registration.yaml)
 
-* [CallHandling service](BYON-CallHandling-Service.yaml)
+* `webrtc-call-handling` [Call handling service](webrtc-call-handling.yaml)
   * This API definition provides functionality for REST clients, browser or native application, to create and manage 1-1 calling. Both incoming and outgoing.
-    * [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/BYON-CallHandling-Service.yaml&nocors)
-    * [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/BYON-CallHandling-Service.yaml)
+    * [View main on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-call-handling.yaml&nocors)
+    * [View main on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-call-handling.yaml)
+
+* `webrtc-events` [WebRTC Event Subscription](webrtc-events.yaml)
+  * This API definition provides functionality for REST clients, browser or native application, to track session events. This will allow the client to receive server side updates about new incoming calls and other needed updates regarding the media negotiation and session progress (ringing, hangup, etc).
+    * [View main on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-events.yaml&nocors)
+    * [View main on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-events.yaml)
+
+* `webrtc-notification-channel` [Notification Channel management](webrtc-notification-channel.yaml)
+  * **API not included on meta-release**
+  * This API definition provides functionality for a REST client, browser or native application, to establish notification channel to receive asynchronous notifications from MNO's IMS Network.
+    * [View main on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-notification-channel.yaml&nocors)
+    * [View main on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-notification-channel.yaml)
 
 Detailed descriptions, diagrams and more information could be found at [API documentation](../../documentation/API_documentation/) section
 
@@ -33,7 +39,7 @@ Use the previous links to check the DEV main version of the API. Copy & paste an
 
 Build an HTML from sources using a local build OpenAPI v3 compatible like Node `redocly/cli`
 
-Execute redocly for each API document, use -o to 
+Execute redocly for each API document, use -o to
 ```
 $ npx @redocly/cli build-docs API_description_file.yaml
 ```

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Bring Your Own Number (BYON) call handling API (VVOIP Service)
+  title: WebRTC Call Handling API
   description: |-
-    ## APIs for REST clients for 1-1 calling
+    ## 1. Introduction
 
     API to create 1-1 voice and video sessions. These, identified by a unique `vvoipSessionId`
     can be recovered, updated and terminated via this API and its methods.
@@ -10,6 +10,8 @@ info:
     - **GET**: Recover an existing session via its unique `vvoipSessionId`
     - **DELETE**: Finish an existing session via its unique `vvoipSessionId`
     - **PUT**: Update the status of a session via its unique `vvoipSessionId`
+
+    To receive server-side updates about the session establishment process, use `webrtc-events` API.
   contact:
     email: contact@domain.com
   license:
@@ -17,14 +19,11 @@ info:
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
   version: 0.1.3
 servers:
-  - url: '{apiRoot}/vvoip/{apiVersion}'
+  - url: '{apiRoot}/webrtc-call-handling/vwip'
     variables:
       apiRoot:
         description: API root
         default: 'http://localhost:9091'
-      apiVersion:
-        description: Version of the VVOIP service API
-        default: v1
 tags:
   - name: OneToOneCall
     description: APIs related to 1-1 voice/video call session

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -96,7 +96,7 @@ info:
     A `org.camaraproject.webrtc-events.v0.session-status` event includes
     session information updates. With the same schema that is used with the
     WebRTC Call Handling API, when retrieving information from the
-    `GET /vvoip/session/{vvoipSessionId}` endpoint.
+    `GET /webrtc-call-handling/session/{vvoipSessionId}` endpoint.
 
     In general lines, it is emitted each time that an event happens within the
     subscribed session. This might happen when SDP updates are included for any

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: BYON WebRTC Event Subscription
+  title: WebRTC Event Subscription
   description: |-
     ## 1. Introduction
 
@@ -44,8 +44,12 @@ info:
       devices using WebRTC sessions.
     - **session**: A media session, an exchange of media between endpoints.
       Typical example of session is a "single one-to-one call".
+    - **vvoipSessionId**: Unique identifier of a Voice and Video **session** using
+      WebRTC technology. Retrieved using the `webrtc-call-handling` API
     - **registration**: An endpoint status were it is properly identified to be
       reachable by the server side of the WebRTC gateway.
+    - **racmSessionId**: Unique identifier of an WebRTC endpoint **registration**.
+      Retrieved using the `webrtc-regsitration` API
 
     ## 3. API functionality
 
@@ -91,7 +95,7 @@ info:
 
     A `org.camaraproject.webrtc-events.v0.session-status` event includes
     session information updates. With the same schema that is used with the
-    WebRTC BYON CallHandling API, when retrieving information from the
+    WebRTC Call Handling API, when retrieving information from the
     `GET /vvoip/session/{vvoipSessionId}` endpoint.
 
     In general lines, it is emitted each time that an event happens within the
@@ -179,7 +183,9 @@ servers:
         description: API root
 tags:
   - name: webrtc-events Subscription
-    description: Operations to manage event subscriptions for WebRTC APIs (BYON and RACM)
+    description: |-
+      Operations to manage event subscriptions for WebRTC Event APIs (Directly
+      related with webrtc-call-handling and webrtc-registration
 
 paths:
   /subscriptions:
@@ -195,7 +201,7 @@ paths:
 
         To subscribe and receive notifications about new calls, a
         `session-invitation` subscription is required using the `racmSessionId`
-        obtained from BYON-RACM API.
+        obtained from webrtc-registration API.
 
         Once you create a new voice-video session or receive an
         new call event, you can subscribe to `session-status` to receive
@@ -739,7 +745,7 @@ components:
           description: |-
             Event details payload. Depending of the event type, it will will include one of the data structures defined on this specification. Along with the subscription-ends, that is an authomatic event.
 
-            Check the introduction documentation and the CAMARA WebRTC BYON APIs for extra info about data structures included on the events.
+            Check the introduction documentation and the other CAMARA WebRTC APIs for extra info about data structures included on the events.
         time:
           $ref: "#/components/schemas/DateTime"
       discriminator:

--- a/code/API_definitions/webrtc-notification-channel.yaml
+++ b/code/API_definitions/webrtc-notification-channel.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 servers:
-  - url: '{apiRoot}/notificationchannel/vwip/{deviceId}'
+  - url: '{apiRoot}/webrtc-notification-channel/vwip/{deviceId}'
     description: APIs to create Notification Channels
     variables:
       apiRoot:

--- a/code/API_definitions/webrtc-notification-channel.yaml
+++ b/code/API_definitions/webrtc-notification-channel.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Bring Your Own Number (BYON) Notification Channel APIs
+  title: WebRTC Notification Channel API
   description: >-
-    This API provide REST API for a client, browser or native application, to
+    This REST API provides functionality for any client, to
     establish notification channel to receive asynchronous notifications from
     MNO's IMS Network.
   version: 0.1.1
@@ -12,15 +12,12 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 servers:
-  - url: '{apiRoot}/notificationchannel/{apiVersion}/{deviceId}'
+  - url: '{apiRoot}/notificationchannel/vwip/{deviceId}'
     description: APIs to create Notification Channels
     variables:
       apiRoot:
         description: API Root
         default: 'http://localhost:9091'
-      apiVersion:
-        description: The version of API to be used
-        default: v1
       deviceId:
         description: >-
           The notification channel creation is specific to a device instance,

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -1,7 +1,17 @@
 openapi: 3.0.3
 info:
-  title: Bring Your Own Number (BYON) Registration and Connectivity Management (RACM) Service APIs
-  description: This API provide REST API for clients to manage Registration and Connectivity (RACM) towards MNO's IMS Network.
+  title: WebRTC Registration and Connectivity Management (RACM) Service API
+  description: |-
+    ## 1. Introduction
+    This API provide REST API for clients to manage Registration and Connectivity (RACM) towards MNO's IMS Network.
+
+    API to create device regsitrations. These, identified by a unique `racmSessionId`
+    can be updated and terminated via this API and its methods.
+    - **POST**: Create a new device registration using a valid authorization token.
+    - **PUT**: Update a device registration via its unique `racmSessionId`
+    - **DELETE**: Finish an existing device registration via its unique `racmSessionId`
+
+    To receive server-side updates about new voice-video sessions, use `webrtc-events` API.
   version: 0.1.2
   contact:
     email: contact@domain.com
@@ -9,15 +19,12 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: '{apiRoot}/racm/{apiVersion}'
+  - url: '{apiRoot}/webrtc-registration/vwip'
     description: APIs to manage Client Registration and Connection
     variables:
       apiRoot:
         description: API Root
         default: http://localhost:9091
-      apiVersion:
-        description: The version of API to be used
-        default: v1
 tags:
   - name: Registration and Connection Management
     description: APIs for Client to Register into MNO's IMS Network


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

According to API Design Guidelines:
api-name is a kebab-case string used to create unique names or values of objects and parameters related to given AP

The API functionalities must be implemented following the specifications of the [Open API version 3.0.3](https://spec.openapis.org/oas/v3.0.3) using api-name as the filename and the .yaml

Servers url:
apiRoot variable and the fixed base path containing api-name
Identified by @rartych at #57 

#### Which issue(s) this PR fixes:

Fixes #57

#### Special notes for reviewers:

Note that Notification-Channel will not be included on final release. Due that, the issue with the URL (ending with /deviceId) won't be fixed on this PR.

#### Changelog input

```
 release-note
 - Fixes #57 - File names and api-name renames according API design guidelines
```

#### Additional documentation 

none
