### PR TITLE
WebRTC r1.1 - Release candidate preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Table of contents
 
+- **[r1.1](#r11)**
 - **[v0.1.1](#v011)**
 - **[v0.1.0](#v010)**
 
@@ -13,6 +14,119 @@ The below sections record the changes for each API version in each release as fo
 * for each first alpha or release-candidate API version, all changes since the release of the previous public API version
 * for subsequent alpha or release-candidate API versions, the delta with respect to the previous pre-release
 * for a public API version, the consolidated changes since the release of the previous public API version
+
+# r1.1
+
+## Release Notes
+
+This pre-release contains the definition and documentation of
+
+* webrtc-registration v0.2.0-rc.1
+* webrtc-call-handling v0.2.0-rc.1
+* webrtc-events v0.1.0-rc.1
+
+The API definition(s) are based on
+
+* Commonalities v0.5.0-rc.1
+* Identity and Consent Management v0.3.0-rc.1
+  
+## WebRTC Registration v0.2.0-rc.1
+
+webrtc-registration v0.2.0-rc.1 is the release candidate of the version 0.2.0 of the API
+
+**There are breaking changes compared to v0.1.1.**: the API use has been simplified for API consumers using a three-legged access token to invoke the API. In these cases the optional `device` parameter MUST NOT be provided, as the subject will be uniquely identified from the access token. In this context also some error response codes have been renamed or replaced to comply with Commonalities 0.5.
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-registration.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-registration.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-registration.yaml)
+
+### Added
+* YAML inline documentation at PR #67
+* Commonalites aligment 0.5 at PR #65
+* Included base testing scenarios at PR #69
+
+### Changed
+* API naming to WebRTC Registarion and filename `webrtc-registration.yaml` PR #59
+* Server `url` based on Commonalities 0.5 at PR #59
+* Security schema `openId` based on Commonalities 0.5 at PR #65
+* Response code based on Commonalities 0.5 at PR #65
+
+### Fixed
+* Descriptions and relevant information for all documentation and schemas
+
+### Removed
+* `BYON` terminology and API naming
+* `notificationChannel` API related paramter `channelId` at PR #67
+* `BearerAuth` in favor of `openId` as security schema at PR #65
+
+## WebRTC Call Handling v0.2.0-rc.1
+
+webrtc-call-handling v0.2.0-rc.1 is the release candidate of the version 0.2.0 of the API
+
+**There are breaking changes compared to v0.1.1.**: the API use has been simplified for API consumers using a three-legged access token to invoke the API. In these cases the optional `device` parameter MUST NOT be provided, as the subject will be uniquely identified from the access token. In this context also some error response codes have been renamed or replaced to comply with Commonalities 0.5.
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-call-handling.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-call-handling.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-call-handling.yaml)
+
+### Added
+* YAML inline documentation at PR #68
+* Commonalites aligment 0.5 at PR #65
+* Included base testing scenarios at PR #69
+
+### Changed
+* API naming to WebRTC Call Handling and filename `webrtc-call-handling.yaml` PR #59
+* Server `url` based on Commonalities 0.5 at PR #59
+* Security schema `openId` based on Commonalities 0.5 at PR #65
+* Response code based on Commonalities 0.5 at PR #65
+* `VvoipSessionInformation` schema expanded, to include all fields used related to a single voice-video session at PR #56
+* `SessionNotification` schema updated at PR #56
+  * It aligns this API with the WebRTC Event notification service. So `SessionNotification` schema, now, its just a wrapper for `VvoipSessionInformation` schema. This way, the developer only need to use one object for notification and voice-video session updates (POST / PUT operations).
+
+### Fixed
+* Descriptions and relevant information for all documentation and schemas
+
+### Removed
+* `BYON` terminology and API naming
+* `BearerAuth` in favor of `openId` as security schema at PR #65
+* `SessionNotification` schema updated at PR #56
+  * `SessionInvitationNotification` - Became part of `SessionNotification` 
+  * `SessionStatusNotification` - Became part of `SessionNotification` 
+
+## WebRTC Events v0.1.0-rc.1
+
+webrtc-events v0.1.0-rc.1 is the release candidate of the version 0.1.0 of the API
+
+**This version defines a new API:**
+
+Initial version covering the following functionality and related endpoints:
+
+* API to subscribe to call events. Bringing server-side updates about a voice video session in progress or during negotiation.
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-events.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-events.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-events.yaml)
+
+### Added
+* YAML inline documentation at PR #53
+* Commonalites aligment 0.5 at PR #66
+* Included `subscriptions` endpoint to create CloudEvents subscrition at PR #53
+  * Endpoints can now define a callback and receive server-side events using CloudEvents
+  * Endpoints can now receive callback events regarding new available audio-video sessions (call incomming)
+  * Endpoints can now receive callback events regarding session establishment updates like network changes and remote session termination (call progress and call hangup)
+* Included base testing scenarios at PR #69
+  
+### Changed
+* n/a
+
+### Fixed
+* n/a
+
+### Removed
+* n/a
 
 # v0.1.1
 

--- a/README.md
+++ b/README.md
@@ -11,25 +11,54 @@ Repository to describe, develop, document and test the WebRTC API family
 ## Scope
 * Service APIs for “WebRTC” (see APIBacklog.md)  
 * It provides the customer with the ability to:  
-  * add real-time communication capabilities to their applications like video, voice, and generic data.
-  * Enable a web endpoint to register for IMS services through a webRTC Gateway using Oauth 2.0 and the Operator provided Identity Provider (IDP)
-  * Open webSockets to receive IMS call events using JSON for the delivery
-  * Make calls from the endpoint (client) side by establishing WebSocket using the channel URL received as part of the registration procedure. 
-
+  * Add real-time communication capabilities to their applications like video, voice, and generic data.
+  * Enable a web endpoint to register for telco services (IMS) through a WebRTC Gateway using Oauth 2.0 and the Operator provided Identity Provider (IDP)
+  * Create subscriptions to receive telco call events using CloudEvents
+  * Make calls from the endpoint (client) side establishing a realiable and media WebSocket channel to exchange secure media.
 * Describe, develop, document and test the APIs (with 1-2 Telcos)  
 * Started: September 2023
 * Location: virtually  
 
-## API Documentation
+## Release Information
+
+* Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest public release**.
+
+* **The pre-release [r1.1](https://github.com/camaraproject/WebRTC/tree/r1.1) contains the release-candidate versions for the Spring25 meta-release.**
+  
+  * **webrtc-registration v0.2.0**
+  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-registration.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-registration.yaml&nocors)
+  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-registration.yaml)
+
+  * **webrtc-call-handling v0.2.0**
+  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-call-handling.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-call-handling.yaml&nocors)
+  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-call-handling.yaml)
+
+  * **webrtc-events v0.1.0**
+  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-events.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-events.yaml&nocors)
+  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.1/code/API_definitions/webrtc-events.yaml)
+
+* Previous releases and pre-releases are available here: https://github.com/camaraproject/WebRTC/releases
+* For changes see [CHANGELOG.md](https://github.com/camaraproject/WebRTC/blob/main/CHANGELOG.md)
+
+## API Extra documentation
 
 * Find API reference documentation at folder: [code/API_definitions](code/API_definitions/)
+* Find API testing documentation at folder: [code/Test_definitions](code/Test_definitions/)
 * Find detailed detailed API explanations at folder: [documentation/API_documentation](documentation/API_documentation)
+* Find other complementary documentation at folder: [documentation/SupportingDocuments](documentation/SupportingDocuments)
+* For other information refer to [Confluence CAMARA project wiki](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14560817/WebRTC)
 
 ## Meetings
 * Meetings are held virtually
   * Find meeting notes at https://wiki.camaraproject.org/display/CAM/WebRTC+Meeting+Minutes
-* Schedule: Tuesdays 4pm CEST (Madrid, Paris, Berlin, Rome), each 15 days
+* Schedule:
+  * Tuesdays 4pm CEST (Madrid, Paris, Berlin, Rome), each 15 days
 * Meeting link: [LFX Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/99827941663?password=ac67c375-4795-4389-93b5-bb5ed5ef0977).
+  
 ## Contributorship and mailing list
+
 * To subscribe / unsubscribe to the mailing list of this Sub Project and thus be / resign as Contributor please visit <https://lists.camaraproject.org/g/sp-rtc>.
 * A message to all Contributors of this Sub Project can be sent using <sp-rtc@lists.camaraproject.org>.

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -17,11 +17,11 @@ info:
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 0.1.3-rc.1
+  version: 0.2-rc.1
   x-camara-commonalities: 0.4.0
 
 servers:
-  - url: '{apiRoot}/webrtc-call-handling/v0'
+  - url: '{apiRoot}/webrtc-call-handling/v0.2'
     variables:
       apiRoot:
         description: API root

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -12,16 +12,14 @@ info:
     - **PUT**: Update the status of a session via its unique `vvoipSessionId`
 
     To receive server-side updates about the session establishment process, use `webrtc-events` API.
-  contact:
-    email: contact@domain.com
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 0.2-rc.1
-  x-camara-commonalities: 0.4.0
+  version: 0.2.0-rc.1
+  x-camara-commonalities: 0.5
 
 servers:
-  - url: '{apiRoot}/webrtc-call-handling/v0.2'
+  - url: '{apiRoot}/webrtc-call-handling/v0.2rc1'
     variables:
       apiRoot:
         description: API root

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -17,9 +17,11 @@ info:
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 0.1.3
+  version: 0.1.3-rc.1
+  x-camara-commonalities: 0.4.0
+
 servers:
-  - url: '{apiRoot}/webrtc-call-handling/vwip'
+  - url: '{apiRoot}/webrtc-call-handling/v0'
     variables:
       apiRoot:
         description: API root

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -169,14 +169,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: 0.1.0-rc.1
   x-camara-commonalities: 0.4.0
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
 servers:
-  - url: "{apiRoot}/webrtc-events/vwip"
+  - url: "{apiRoot}/webrtc-events/v0"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -170,13 +170,13 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.1.0-rc.1
-  x-camara-commonalities: 0.4.0
+  x-camara-commonalities: 0.5
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
 servers:
-  - url: "{apiRoot}/webrtc-events/v0.1"
+  - url: "{apiRoot}/webrtc-events/v0.1rc1"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -176,7 +176,7 @@ externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
 servers:
-  - url: "{apiRoot}/webrtc-events/v0"
+  - url: "{apiRoot}/webrtc-events/v0.1"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -17,11 +17,10 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.3-rc.1
+  version: 0.2-rc.1
   x-camara-commonalities: 0.4.0
-  
 servers:
-  - url: '{apiRoot}/webrtc-registration/v0'
+  - url: '{apiRoot}/webrtc-registration/v0.2'
     description: APIs to manage Client Registration and Connection
     variables:
       apiRoot:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -12,15 +12,13 @@ info:
     - **DELETE**: Finish an existing device registration via its unique `racmSessionId`
 
     To receive server-side updates about new voice-video sessions, use `webrtc-events` API.
-  contact:
-    email: contact@domain.com
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.2-rc.1
-  x-camara-commonalities: 0.4.0
+  version: 0.2.0-rc.1
+  x-camara-commonalities: 0.5
 servers:
-  - url: '{apiRoot}/webrtc-registration/v0.2'
+  - url: '{apiRoot}/webrtc-registration/v0.2rc1'
     description: APIs to manage Client Registration and Connection
     variables:
       apiRoot:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -12,14 +12,16 @@ info:
     - **DELETE**: Finish an existing device registration via its unique `racmSessionId`
 
     To receive server-side updates about new voice-video sessions, use `webrtc-events` API.
-  version: 0.1.2
   contact:
     email: contact@domain.com
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.1.3-rc.1
+  x-camara-commonalities: 0.4.0
+  
 servers:
-  - url: '{apiRoot}/webrtc-registration/vwip'
+  - url: '{apiRoot}/webrtc-registration/v0'
     description: APIs to manage Client Registration and Connection
     variables:
       apiRoot:

--- a/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
@@ -1,18 +1,18 @@
 # API WebRTC Call Handling
 
-Checklist for webrtc-call-handling v0.1.3-rc.1
+Checklist for webrtc-call-handling v0.2.0-rc.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
-|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [link](/code/API_definitions/webrtc-call-handling.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | 0.4  |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      |   |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | SemVer 2.0.0 |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | [link](/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md) |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |      |   |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      |   |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      |   |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      |   |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |   |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [link](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      |   |
+|----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-call-handling.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |  tbd  | 0.5   |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |  tbd  | 0.3.0 |
+|  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
+|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | [link](/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md) |
+|  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
+|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
+|  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |
+|  9 | Test result statement                        |   O   |   O   |   O   |   M   |   N   |   |
+| 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |
+| 11 | Change log updated                           |   M   |   M   |   M   |   M   |  tbd  | [link](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
@@ -1,0 +1,18 @@
+# API WebRTC Call Handling
+
+Checklist for webrtc-call-handling v0.1.3-rc.1
+
+| Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
+|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
+|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [link](/code/API_definitions/webrtc-call-handling.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | 0.4  |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      |   |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | SemVer 2.0.0 |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | [link](/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md) |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |      |   |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      |   |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      |   |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      |   |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |   |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [link](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      |   |

--- a/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
@@ -10,7 +10,7 @@ Checklist for webrtc-call-handling v0.2.0-rc.1
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
-|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
+|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |   Y   | [link](/code/Test_definitions/) |
 |  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |
 |  9 | Test result statement                        |   O   |   O   |   O   |   M   |   N   |   |
 | 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |

--- a/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
@@ -8,7 +8,7 @@ Checklist for webrtc-call-handling v0.2.0-rc.1
 |  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |  tbd  | 0.5   |
 |  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |  tbd  | 0.3.0 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
-|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | [link](/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md) |
+|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
 |  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
 |  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -1,0 +1,18 @@
+# API WebRTC events
+
+Checklist for webrtc-events v0.1.0-rc.1
+
+| Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
+|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
+|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [link](/code/API_definitions/webrtc-events.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | 0.4  |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      |   |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | SemVer 2.0.0 |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | [link](/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md) |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |      |   |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      |   |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      |   |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      |   |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |   |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [link](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      |   |

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -8,7 +8,7 @@ Checklist for webrtc-events v0.1.0-rc.1
 |  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |  tbd  | 0.5   |
 |  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |  tbd  | 0.3.0 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
-|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | [link](/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md) |
+|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
 |  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
 |  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -10,7 +10,7 @@ Checklist for webrtc-events v0.1.0-rc.1
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
-|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
+|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |   Y   | [link](/code/Test_definitions/) |
 |  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |
 |  9 | Test result statement                        |   O   |   O   |   O   |   M   |   N   |   |
 | 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -3,16 +3,16 @@
 Checklist for webrtc-events v0.1.0-rc.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
-|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [link](/code/API_definitions/webrtc-events.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | 0.4  |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      |   |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | SemVer 2.0.0 |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | [link](/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md) |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |      |   |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      |   |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      |   |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      |   |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |   |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [link](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      |   |
+|----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-events.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |  tbd  | 0.5   |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |  tbd  | 0.3.0 |
+|  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
+|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | [link](/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md) |
+|  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
+|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
+|  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |
+|  9 | Test result statement                        |   O   |   O   |   O   |   M   |   N   |   |
+| 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |
+| 11 | Change log updated                           |   M   |   M   |   M   |   M   |  tbd  | [link](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -1,18 +1,18 @@
 # API WebRTC Registration
 
-Checklist for webrtc-registration v0.1.3-rc.1
+Checklist for webrtc-registration v0.2.0-rc.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
-|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [link](/code/API_definitions/webrtc-registration.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | 0.4  |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      |   |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | SemVer 2.0.0 |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | [link](/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md) |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |      |   |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      |   |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      |   |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      |   |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |   |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [link](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      |   |
+|----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-registration.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |  tbd  | 0.5   |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |  tbd  | 0.3.0 |
+|  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
+|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | [link](/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md) |
+|  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
+|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
+|  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |
+|  9 | Test result statement                        |   O   |   O   |   O   |   M   |   N   |   |
+| 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |
+| 11 | Change log updated                           |   M   |   M   |   M   |   M   |  tbd  | [link](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -8,7 +8,7 @@ Checklist for webrtc-registration v0.2.0-rc.1
 |  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |  tbd  | 0.5   |
 |  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |  tbd  | 0.3.0 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
-|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | [link](/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md) |
+|  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
 |  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
 |  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -10,7 +10,7 @@ Checklist for webrtc-registration v0.2.0-rc.1
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   | SemVer 2.0.0 |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
-|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |  tbd  | [link](/documentation/API_documentation/) |
+|  7 | Basic API test cases & documentation         |   O   |   M   |   M   |   M   |   Y   | [link](/code/Test_definitions/) |
 |  8 | Enhanced API test cases & documentation      |   O   |   O   |   O   |   M   |   N   |   |
 |  9 | Test result statement                        |   O   |   O   |   O   |   M   |   N   |   |
 | 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -1,0 +1,18 @@
+# API WebRTC Registration
+
+Checklist for webrtc-registration v0.1.3-rc.1
+
+| Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
+|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
+|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [link](/code/API_definitions/webrtc-registration.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | 0.4  |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      |   |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | SemVer 2.0.0 |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | [link](/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md) |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |      |   |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      |   |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      |   |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      |   |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |   |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [link](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      |   |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation
* subproject management

#### What this PR does / why we need it:

* Release process to create first public release candidate for WebRTC APIs
* Target release r0.1.1 (not tagged yet)

#### Which issue(s) this PR fixes:

Fixes #50 
Fixes #51
Fixes #61 
Fixes #60 
Fixes #58 

#### Special notes for reviewers:

This PR intend to solve any formality and documentation requirements to achieve public release status within the repository and APIs: webrtc-registration, webrtc-call-handling, and webrtc-events. No functionality changes are intended.

#### Changelog input

```
Version URL path to rc.1
- webrtc-registration: 0.2.0-rc.1
- webrtc-call-handling: 0.2.0-rc.1
- webrtc-events: 0.1.0-rc.1
```

#### Additional documentation 

```
API readiness checklist for webrtc-registration
API readiness checklist for webrtc-call-handling
API readiness checklist for webrtc-events
```
