### PR TITLE
WebRTC Release r2.1 candidate for Fall25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,13 @@ Changelog since latest public r1.2
 * Added 200 OK response definition for `PUT /sessions/{registrationId}` to acknowledge successful updates.
 
 ### Changed
-* Commonalities aligment 0.6 at PR #XX
-* Extended `regSessionResponse` schema to include `expiresAt`, indicating the assigned expiry time of the registration session.
+* Commonalities aligment 0.6 at PR #88
+  * fix: Remove AUTHENTICATION_REQUIRED error code
+  * doc: Update `types` (multiple) property of `Subscription` schema
+  * feat: Error 422 MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED added
+  * fix: Remove IDENTIFIER_MISMATCH error
+  * fix: x-correlator format update, along test and schema update 
+* Extended `regSessionResponse` schema to include `expiresAt`, indicating the assigned expiry time of the registration session at PR #83
 
 ## webrtc-call-handling v0.3.0-rc.1
 
@@ -61,7 +66,12 @@ Changelog since latest public r1.2
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-call-handling.yaml)
 
 ### Changes
-* Commonalities aligment 0.6 at PR #XX
+* Commonalities aligment 0.6 at PR #88
+  * fix: Remove AUTHENTICATION_REQUIRED error code
+  * doc: Update `types` (multiple) property of `Subscription` schema
+  * feat: Error 422 MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED added
+  * fix: Remove IDENTIFIER_MISMATCH error
+  * fix: x-correlator format update, along test and schema update
 
 ## WebRTC Events v0.2.0-rc.1
 
@@ -71,12 +81,17 @@ Changelog since latest public r1.2
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-events.yaml)
 
 ### Added
-* Added new event type `webrtc-events:org.camaraproject.webrtc-events.v0.registration-ends` to notify subscribers when a registration ends.
+* Added new event type `webrtc-events:org.camaraproject.webrtc-events.v0.registration-ends` to notify subscribers when a registration ends at PR #83
 * Provided a concrete example for the `registration-ends` event subscription.
 
 ### Changes
-* Commonalities aligment 0.6 at PR #XX
-* Extended `TerminationReason` enumeration to include `REGISTRATION_EXPIRED`, allowing precise classification of expiry-based terminations.
+* Commonalities aligment 0.6 at PR #88
+  * fix: Remove AUTHENTICATION_REQUIRED error code
+  * doc: Update `types` (multiple) property of `Subscription` schema
+  * feat: Error 422 MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED added
+  * fix: Remove IDENTIFIER_MISMATCH error
+  * fix: x-correlator format update, along test and schema update
+* Extended `TerminationReason` enumeration to include `REGISTRATION_EXPIRED`, allowing precise classification of expiry-based terminations at PR #83
 
 # r1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,20 +45,20 @@ Changelog since latest public r1.2
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-registration.yaml)
 
 ### Added
-* Support registration expiry updates and termination event notifications at PR #83
+* Support registration expiry updates and termination event notifications at PR [#83](https://github.com/camaraproject/WebRTC/pull/83)
 * Introduced `regSessionUpdate` schema with optional `registrationExpireTime` field to allow clients to request a new expiry time.
 * Added 200 OK response definition for `PUT /sessions/{registrationId}` to acknowledge successful updates.
 
 ### Changed
-* fix: Updated deviceId format, examples and tests at #91
-* fix: registrationId became mandatory on registration response at #93
-* Commonalities aligment 0.6 at PR #88
+* fix: Updated deviceId format, examples and tests at [#91](https://github.com/camaraproject/WebRTC/pull/91)
+* fix: registrationId became mandatory on registration response at [#93](https://github.com/camaraproject/WebRTC/pull/93)
+* Commonalities aligment 0.6 at PR [#88](https://github.com/camaraproject/WebRTC/pull/88)
   * fix: Remove AUTHENTICATION_REQUIRED error code
   * doc: Update `types` (multiple) property of `Subscription` schema
   * feat: Error 422 MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED added
   * fix: Remove IDENTIFIER_MISMATCH error
   * fix: x-correlator format update, along test and schema update 
-* Extended `regSessionResponse` schema to include `expiresAt`, indicating the assigned expiry time of the registration session at PR #83
+* Extended `regSessionResponse` schema to include `expiresAt`, indicating the assigned expiry time of the registration session at PR [#83](https://github.com/camaraproject/WebRTC/pull/83)
 
 ## webrtc-call-handling v0.3.0-rc.1
 
@@ -68,8 +68,8 @@ Changelog since latest public r1.2
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-call-handling.yaml)
 
 ### Changes
-* fix: Added 400 error response at #91
-* Commonalities aligment 0.6 at PR #88
+* fix: Added 400 error response at [#91](https://github.com/camaraproject/WebRTC/pull/91)
+* Commonalities aligment 0.6 at PR [#88](https://github.com/camaraproject/WebRTC/pull/88)
   * fix: Remove AUTHENTICATION_REQUIRED error code
   * doc: Update `types` (multiple) property of `Subscription` schema
   * feat: Error 422 MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED added
@@ -84,19 +84,19 @@ Changelog since latest public r1.2
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-events.yaml)
 
 ### Added
-* Added new event type `webrtc-events:org.camaraproject.webrtc-events.v0.registration-ends` to notify subscribers when a registration ends at PR #83
+* Added new event type `webrtc-events:org.camaraproject.webrtc-events.v0.registration-ends` to notify subscribers when a registration ends at PR [#83](https://github.com/camaraproject/WebRTC/pull/83)
 * Provided a concrete example for the `registration-ends` event subscription.
 
 ### Changes
-* fix: Updated deviceId format, examples and tests at #91
-* fix: Updated mandatory fields per specific event data callback at #94
-* Commonalities aligment 0.6 at PR #88
+* fix: Updated deviceId format, examples and tests at [#91](https://github.com/camaraproject/WebRTC/pull/91)
+* fix: Updated mandatory fields per specific event data callback at [#94](https://github.com/camaraproject/WebRTC/pull/94)
+* Commonalities aligment 0.6 at PR [#88](https://github.com/camaraproject/WebRTC/pull/88)
   * fix: Remove AUTHENTICATION_REQUIRED error code
   * doc: Update `types` (multiple) property of `Subscription` schema
   * feat: Error 422 MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED added
   * fix: Remove IDENTIFIER_MISMATCH error
   * fix: x-correlator format update, along test and schema update
-* Extended `TerminationReason` enumeration to include `REGISTRATION_EXPIRED`, allowing precise classification of expiry-based terminations at PR #83
+* Extended `TerminationReason` enumeration to include `REGISTRATION_EXPIRED`, allowing precise classification of expiry-based terminations at PR [#83](https://github.com/camaraproject/WebRTC/pull/83)
 
 # r1.2
 
@@ -127,16 +127,16 @@ Changelog since latest public v0.1.1
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-registration.yaml)
 
 ### Added
-* YAML inline documentation at PR #67
-* Commonalites aligment 0.5 at PR #65
-* Included base testing scenarios at PR #69
-* Included basic error testing at PR #71
+* YAML inline documentation at PR [#67](https://github.com/camaraproject/WebRTC/pull/67)
+* Commonalites aligment 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Included base testing scenarios at PR [#69](https://github.com/camaraproject/WebRTC/pull/69)
+* Included basic error testing at PR [#71](https://github.com/camaraproject/WebRTC/pull/71)
 
 ### Changed
-* API naming to WebRTC Registarion and filename `webrtc-registration.yaml` PR #59
-* Server `url` based on Commonalities 0.5 at PR #59
-* Security schema `openId` based on Commonalities 0.5 at PR #65
-* Response code based on Commonalities 0.5 at PR #65
+* API naming to WebRTC Registarion and filename `webrtc-registration.yaml` PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Server `url` based on Commonalities 0.5 at PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Security schema `openId` based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Response code based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
 * Term `RACM` is replaced by `Registration` or `reg` suffix
 * TransactionId header (required) was replaced by x-correlator header (optional)
 * `msisdn` response is now `phoneNumber`
@@ -151,8 +151,8 @@ Changelog since latest public v0.1.1
 
 ### Removed
 * `BYON` terminology and API naming
-* `notificationChannel` API related parameter `channelId` at PR #67
-* `BearerAuth` in favor of `openId` as security schema at PR #65
+* `notificationChannel` API related parameter `channelId` at PR [#67](https://github.com/camaraproject/WebRTC/pull/67)
+* `BearerAuth` in favor of `openId` as security schema at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
 * Removed generic 5xx reponses
 * `clientId` header is removed
 
@@ -166,18 +166,18 @@ Changelog since latest public v0.1.1
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-call-handling.yaml)
 
 ### Added
-* YAML inline documentation at PR #68
-* Commonalites aligment 0.5 at PR #65
-* Included base testing scenarios at PR #69
+* YAML inline documentation at PR [#68](https://github.com/camaraproject/WebRTC/pull/68)
+* Commonalites aligment 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Included base testing scenarios at PR [#69](https://github.com/camaraproject/WebRTC/pull/69)
 * Included basic error testing
 
 ### Changed
-* API naming to WebRTC Call Handling and filename `webrtc-call-handling.yaml` PR #59
-* Server `url` based on Commonalities 0.5 at PR #59
-* Security schema `openId` based on Commonalities 0.5 at PR #65
-* Response code based on Commonalities 0.5 at PR #65
-* `MediaSessionInformation` schema expanded, to include all fields used related to a single voice-video session at PR #56
-* `SessionNotification` schema updated at PR #56
+* API naming to WebRTC Call Handling and filename `webrtc-call-handling.yaml` PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Server `url` based on Commonalities 0.5 at PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Security schema `openId` based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Response code based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* `MediaSessionInformation` schema expanded, to include all fields used related to a single voice-video session at PR [#56](https://github.com/camaraproject/WebRTC/pull/56)
+* `SessionNotification` schema updated at PR [#56](https://github.com/camaraproject/WebRTC/pull/56)
   * It aligns this API with the WebRTC Event notification service. So `SessionNotification` schema, now, its just a wrapper for `MediaSessionInformation` schema. This way, the developer only need to use one object for notification and voice-video session updates (POST / PUT operations).
 * Term `RACM` is replaced by `Registration` or `reg` suffix
 * Suffix `vvoip` is replaced by `media` to identify media sessions, like calls, video-calls or any media session
@@ -191,8 +191,8 @@ Changelog since latest public v0.1.1
 
 ### Removed
 * `BYON` terminology and API naming
-* `BearerAuth` in favor of `openId` as security schema at PR #65
-* `SessionNotification` schema updated at PR #56
+* `BearerAuth` in favor of `openId` as security schema at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* `SessionNotification` schema updated at PR [#56](https://github.com/camaraproject/WebRTC/pull/56)
   * `SessionInvitationNotification` - Became part of `SessionNotification`
   * `SessionStatusNotification` - Became part of `SessionNotification`
 * Removed generic 5xx reponses
@@ -212,13 +212,13 @@ Initial version covering the following functionality and related endpoints:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-events-subscription.yaml)
 
 ### Added
-* YAML inline documentation at PR #53
-* Commonalites aligment 0.5 at PR #66
-* Included `subscriptions` endpoint to create CloudEvents subscrition at PR #53
+* YAML inline documentation at PR [#53](https://github.com/camaraproject/WebRTC/pull/53)
+* Commonalites aligment 0.5 at PR [#66](https://github.com/camaraproject/WebRTC/pull/66)
+* Included `subscriptions` endpoint to create CloudEvents subscrition at PR [#53](https://github.com/camaraproject/WebRTC/pull/53)
   * Endpoints can now define a callback and receive server-side events using CloudEvents
   * Endpoints can now receive callback events regarding new available audio-video sessions (call incomming)
   * Endpoints can now receive callback events regarding session establishment updates like network changes and remote session termination (call progress and call hangup)
-* Included base testing scenarios at PR #69
+* Included base testing scenarios at PR [#69](https://github.com/camaraproject/WebRTC/pull/69)
 * Included basic error testing
 
 ### Changed
@@ -255,23 +255,23 @@ webrtc-registration v0.2.0-rc.1 is the release candidate of the version 0.2.0 of
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-registration.yaml)
 
 ### Added
-* YAML inline documentation at PR #67
-* Commonalites aligment 0.5 at PR #65
-* Included base testing scenarios at PR #69
+* YAML inline documentation at PR [#67](https://github.com/camaraproject/WebRTC/pull/67)
+* Commonalites aligment 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Included base testing scenarios at PR [#69](https://github.com/camaraproject/WebRTC/pull/69)
 
 ### Changed
-* API naming to WebRTC Registarion and filename `webrtc-registration.yaml` PR #59
-* Server `url` based on Commonalities 0.5 at PR #59
-* Security schema `openId` based on Commonalities 0.5 at PR #65
-* Response code based on Commonalities 0.5 at PR #65
+* API naming to WebRTC Registarion and filename `webrtc-registration.yaml` PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Server `url` based on Commonalities 0.5 at PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Security schema `openId` based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Response code based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
 
 ### Fixed
 * Descriptions and relevant information for all documentation and schemas
 
 ### Removed
 * `BYON` terminology and API naming
-* `notificationChannel` API related paramter `channelId` at PR #67
-* `BearerAuth` in favor of `openId` as security schema at PR #65
+* `notificationChannel` API related paramter `channelId` at PR [#67](https://github.com/camaraproject/WebRTC/pull/67)
+* `BearerAuth` in favor of `openId` as security schema at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
 
 ## WebRTC Call Handling v0.2.0-rc.1
 
@@ -285,17 +285,17 @@ webrtc-call-handling v0.2.0-rc.1 is the release candidate of the version 0.2.0 o
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-call-handling.yaml)
 
 ### Added
-* YAML inline documentation at PR #68
-* Commonalites aligment 0.5 at PR #65
-* Included base testing scenarios at PR #69
+* YAML inline documentation at PR [#68](https://github.com/camaraproject/WebRTC/pull/68)
+* Commonalites aligment 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Included base testing scenarios at PR [#69](https://github.com/camaraproject/WebRTC/pull/69)
 
 ### Changed
-* API naming to WebRTC Call Handling and filename `webrtc-call-handling.yaml` PR #59
-* Server `url` based on Commonalities 0.5 at PR #59
-* Security schema `openId` based on Commonalities 0.5 at PR #65
-* Response code based on Commonalities 0.5 at PR #65
-* `MediaSessionInformation` schema expanded, to include all fields used related to a single voice-video session at PR #56
-* `SessionNotification` schema updated at PR #56
+* API naming to WebRTC Call Handling and filename `webrtc-call-handling.yaml` PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Server `url` based on Commonalities 0.5 at PR [#59](https://github.com/camaraproject/WebRTC/pull/59)
+* Security schema `openId` based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* Response code based on Commonalities 0.5 at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* `MediaSessionInformation` schema expanded, to include all fields used related to a single voice-video session at PR [#56](https://github.com/camaraproject/WebRTC/pull/56)
+* `SessionNotification` schema updated at PR [#56](https://github.com/camaraproject/WebRTC/pull/56)
   * It aligns this API with the WebRTC Event notification service. So `SessionNotification` schema, now, its just a wrapper for `MediaSessionInformation` schema. This way, the developer only need to use one object for notification and voice-video session updates (POST / PUT operations).
 
 ### Fixed
@@ -303,8 +303,8 @@ webrtc-call-handling v0.2.0-rc.1 is the release candidate of the version 0.2.0 o
 
 ### Removed
 * `BYON` terminology and API naming
-* `BearerAuth` in favor of `openId` as security schema at PR #65
-* `SessionNotification` schema updated at PR #56
+* `BearerAuth` in favor of `openId` as security schema at PR [#65](https://github.com/camaraproject/WebRTC/pull/65)
+* `SessionNotification` schema updated at PR [#56](https://github.com/camaraproject/WebRTC/pull/56)
   * `SessionInvitationNotification` - Became part of `SessionNotification`
   * `SessionStatusNotification` - Became part of `SessionNotification`
 
@@ -324,13 +324,13 @@ Initial version covering the following functionality and related endpoints:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.1/code/API_definitions/webrtc-events.yaml)
 
 ### Added
-* YAML inline documentation at PR #53
-* Commonalites aligment 0.5 at PR #66
-* Included `subscriptions` endpoint to create CloudEvents subscrition at PR #53
+* YAML inline documentation at PR [#53](https://github.com/camaraproject/WebRTC/pull/53)
+* Commonalites aligment 0.5 at PR [#66](https://github.com/camaraproject/WebRTC/pull/66)
+* Included `subscriptions` endpoint to create CloudEvents subscrition at PR [#53](https://github.com/camaraproject/WebRTC/pull/53)
   * Endpoints can now define a callback and receive server-side events using CloudEvents
   * Endpoints can now receive callback events regarding new available audio-video sessions (call incomming)
   * Endpoints can now receive callback events regarding session establishment updates like network changes and remote session termination (call progress and call hangup)
-* Included base testing scenarios at PR #69
+* Included base testing scenarios at PR [#69](https://github.com/camaraproject/WebRTC/pull/69)
 
 ### Changed
 * n/a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Table of contents
 
+- **[r1.3](#r13)**
 - **[r1.2](#r12)**
 - **[r1.1](#r11)**
 - **[v0.1.1](#v011)**
@@ -16,6 +17,66 @@ The below sections record the changes for each API version in each release as fo
 * for the first release-candidate, all changes since the last public release
 * for subsequent release-candidate(s), only the delta to the previous release-candidate
 * for a public release, the consolidated changes since the previous public release
+
+# r1.3
+
+## Release Notes
+
+This public release contains the definition and documentation of
+
+* webrtc-registration v0.2.0
+* webrtc-call-handling v0.2.0
+* webrtc-events v0.1.0
+
+The API definition(s) are based on
+
+* Commonalities r3.2
+* Identity and Consent Management r3.2
+
+Changelog since latest public r1.2
+
+* Full Changelog with the list of PRs and contributors: https://github.com/camaraproject/WebRTC/compare/r1.2...r1.3
+
+## WebRTC Registration v0.3.0
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-registration.yaml)
+
+### Added
+* Support registration expiry updates and termination event notifications at PR #83
+* Introduced `regSessionUpdate` schema with optional `registrationExpireTime` field to allow clients to request a new expiry time.
+* Added 200 OK response definition for `PUT /sessions/{registrationId}` to acknowledge successful updates.
+
+### Changed
+* Commonalities aligment 0.6 at PR #XX
+* Extended `regSessionResponse` schema to include `expiresAt`, indicating the assigned expiry time of the registration session.
+
+## webrtc-call-handling v0.2.0
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-call-handling.yaml)
+
+### Changes
+* Commonalities aligment 0.6 at PR #XX
+
+## WebRTC Events v0.1.0
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-events.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-events.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-events.yaml)
+
+### Added
+* Added new event type `webrtc-events:org.camaraproject.webrtc-events.v0.registration-ends` to notify subscribers when a registration ends.
+* Provided a concrete example for the `registration-ends` event subscription.
+
+### Changes
+* Commonalities aligment 0.6 at PR #XX
+* Extended `TerminationReason` enumeration to include `REGISTRATION_EXPIRED`, allowing precise classification of expiry-based terminations.
 
 # r1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Changelog since latest public r1.2
 * Added 200 OK response definition for `PUT /sessions/{registrationId}` to acknowledge successful updates.
 
 ### Changed
+* fix: Updated deviceId format, examples and tests at #91
+* fix: registrationId became mandatory on registration response at #93
 * Commonalities aligment 0.6 at PR #88
   * fix: Remove AUTHENTICATION_REQUIRED error code
   * doc: Update `types` (multiple) property of `Subscription` schema
@@ -66,6 +68,7 @@ Changelog since latest public r1.2
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-call-handling.yaml)
 
 ### Changes
+* fix: Added 400 error response at #91
 * Commonalities aligment 0.6 at PR #88
   * fix: Remove AUTHENTICATION_REQUIRED error code
   * doc: Update `types` (multiple) property of `Subscription` schema
@@ -85,6 +88,8 @@ Changelog since latest public r1.2
 * Provided a concrete example for the `registration-ends` event subscription.
 
 ### Changes
+* fix: Updated deviceId format, examples and tests at #91
+* fix: Updated mandatory fields per specific event data callback at #94
 * Commonalities aligment 0.6 at PR #88
   * fix: Remove AUTHENTICATION_REQUIRED error code
   * doc: Update `types` (multiple) property of `Subscription` schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The below sections record the changes for each API version in each release as fo
 
 ## Release Notes
 
-This public release contains the definition and documentation of
+This pre-release contains the definition and documentation of
 
 * webrtc-registration v0.3.0-rc.1
 * webrtc-call-handling v0.3.0-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Table of contents
 
-- **[r1.3](#r13)**
+- **[r2.1](#r21)**
 - **[r1.2](#r12)**
 - **[r1.1](#r11)**
 - **[v0.1.1](#v011)**
@@ -18,15 +18,15 @@ The below sections record the changes for each API version in each release as fo
 * for subsequent release-candidate(s), only the delta to the previous release-candidate
 * for a public release, the consolidated changes since the previous public release
 
-# r1.3
+# r2.1
 
 ## Release Notes
 
 This public release contains the definition and documentation of
 
-* webrtc-registration v0.2.0
-* webrtc-call-handling v0.2.0
-* webrtc-events v0.1.0
+* webrtc-registration v0.3.0-rc.1
+* webrtc-call-handling v0.3.0-rc.1
+* webrtc-events v0.2.0-rc.1
 
 The API definition(s) are based on
 
@@ -35,14 +35,14 @@ The API definition(s) are based on
 
 Changelog since latest public r1.2
 
-* Full Changelog with the list of PRs and contributors: https://github.com/camaraproject/WebRTC/compare/r1.2...r1.3
+* Full Changelog with the list of PRs and contributors: https://github.com/camaraproject/WebRTC/compare/r1.2...r2.1
 
-## WebRTC Registration v0.3.0
+## WebRTC Registration v0.3.0-rc.1
 
 - API definition **with inline documentation**:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml&nocors)
-  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-registration.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-registration.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-registration.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-registration.yaml)
 
 ### Added
 * Support registration expiry updates and termination event notifications at PR #83
@@ -53,17 +53,17 @@ Changelog since latest public r1.2
 * Commonalities aligment 0.6 at PR #XX
 * Extended `regSessionResponse` schema to include `expiresAt`, indicating the assigned expiry time of the registration session.
 
-## webrtc-call-handling v0.2.0
+## webrtc-call-handling v0.3.0-rc.1
 
 - API definition **with inline documentation**:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-call-handling.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-call-handling.yaml)
 
 ### Changes
 * Commonalities aligment 0.6 at PR #XX
 
-## WebRTC Events v0.1.0
+## WebRTC Events v0.2.0-rc.1
 
 - API definition **with inline documentation**:
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-events.yaml&nocors)

--- a/README.md
+++ b/README.md
@@ -26,25 +26,25 @@ Sandbox API Repository to describe, develop, document, and test the WebRTC Servi
 ## Release Information
 
 * The latest public release is available here: https://github.com/camaraproject/WebRTC/releases/latest
-* For changes see [CHANGELOG.md](CHANGELOG.md)
+  * The latest **public** release is **[r1.2](https://github.com/camaraproject/WebRTC/tree/r1.2) (Spring25 meta-release)**
+  * The latest **pre-release** is **[r2.1](https://github.com/camaraproject/WebRTC/tree/r2.1) (Fall25 meta-release)** with the following API definitions:
+    
+    * **webrtc-registration v0.3.0-rc.1**
+    [[YAML]](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-registration.yaml)
+    [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-registration.yaml&nocors)
+    [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-registration.yaml)
+
+    * **webrtc-call-handling v0.2.0-rc.1**
+    [[YAML]](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-call-handling.yaml)
+    [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml&nocors)
+    [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml)
+
+    * **webrtc-events v0.2.0-rc.1**
+  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-events.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-events.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-events.yaml)
+
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest public release**.
-
-* The latest release is **[r1.3](https://github.com/camaraproject/WebRTC/tree/r1.3) (Fall25 meta-release)** with the following API definitions:
-  
-  * **webrtc-registration v0.3.0**
-  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-registration.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml&nocors)
-  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml)
-
-  * **webrtc-call-handling v0.2.0**
-  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-call-handling.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml&nocors)
-  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml)
-
-  * **webrtc-events v0.2.0**
-  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-events.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-events.yaml&nocors)
-  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-events.yaml)
 
 * Previous releases and pre-releases are available here: https://github.com/camaraproject/WebRTC/releases
 * For changes see [CHANGELOG.md](https://github.com/camaraproject/WebRTC/blob/main/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <a href="https://github.com/camaraproject/WebRTC/graphs/contributors" title="Contributors"><img src="https://img.shields.io/github/contributors/camaraproject/WebRTC?style=plastic"></a>
 <a href="https://github.com/camaraproject/WebRTC" title="Repo Size"><img src="https://img.shields.io/github/repo-size/camaraproject/WebRTC?style=plastic"></a>
 <a href="https://github.com/camaraproject/WebRTC/blob/main/LICENSE" title="License"><img src="https://img.shields.io/badge/License-Apache%202.0-green.svg?style=plastic"></a>
-<a href="https://github.com/camaraproject/{{repo_name}}/releases/latest" title="Latest Release"><img src="https://img.shields.io/github/release/camaraproject/{{repo_name}}?style=plastic"></a>
+<a href="https://github.com/camaraproject/WebRTC/releases/latest" title="Latest Release"><img src="https://img.shields.io/github/release/camaraproject/WebRTC?style=plastic"></a>
 <a href="https://github.com/camaraproject/Governance/blob/main/ProjectStructureAndRoles.md" title="Sandbox API Repository"><img src="https://img.shields.io/badge/Sandbox%20API%20Repository-yellow?style=plastic"></a>
 
 # WebRTC

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Sandbox API Repository to describe, develop, document, and test the WebRTC Servi
     [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-registration.yaml&nocors)
     [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-registration.yaml)
 
-    * **webrtc-call-handling v0.2.0-rc.1**
+    * **webrtc-call-handling v0.3.0-rc.1**
     [[YAML]](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-call-handling.yaml)
     [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml&nocors)
     [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml)

--- a/README.md
+++ b/README.md
@@ -29,22 +29,22 @@ Sandbox API Repository to describe, develop, document, and test the WebRTC Servi
 * For changes see [CHANGELOG.md](CHANGELOG.md)
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest public release**.
 
-* The latest release is **[r1.2](https://github.com/camaraproject/WebRTC/tree/r1.2) (Spring25 meta-release)** with the following API definitions:
+* The latest release is **[r1.3](https://github.com/camaraproject/WebRTC/tree/r1.3) (Fall25 meta-release)** with the following API definitions:
   
-  * **webrtc-registration v0.2.0**
-  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-registration.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-registration.yaml&nocors)
-  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-registration.yaml)
+  * **webrtc-registration v0.3.0**
+  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-registration.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-registration.yaml)
 
   * **webrtc-call-handling v0.2.0**
-  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-call-handling.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-call-handling.yaml&nocors)
-  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-call-handling.yaml)
+  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-call-handling.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-call-handling.yaml)
 
-  * **webrtc-events v0.1.0**
-  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-events-subscription.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-events-subscription.yaml&nocors)
-  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-events-subscription.yaml)
+  * **webrtc-events v0.2.0**
+  [[YAML]](https://github.com/camaraproject/WebRTC/blob/r1.3/code/API_definitions/webrtc-events.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-events.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.3/code/API_definitions/webrtc-events.yaml)
 
 * Previous releases and pre-releases are available here: https://github.com/camaraproject/WebRTC/releases
 * For changes see [CHANGELOG.md](https://github.com/camaraproject/WebRTC/blob/main/CHANGELOG.md)

--- a/code/API_definitions/README.MD
+++ b/code/API_definitions/README.MD
@@ -1,6 +1,6 @@
 # WebRTC APIs definitions
 
-This folder contain the OpenAPI v3 definition of the WebRTC subgroup
+This folder contain the OpenAPI definitions of the WebRTC subgroup
 
 ## APIs included
 
@@ -18,12 +18,6 @@ This folder contain the OpenAPI v3 definition of the WebRTC subgroup
   * This API definition provides functionality for REST clients, browser or native application, to track session events. This will allow the client to receive server side updates about new incoming calls and other needed updates regarding the media negotiation and session progress (ringing, hangup, etc).
     * [View main on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-events.yaml&nocors)
     * [View main on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-events.yaml)
-
-* `webrtc-notification-channel` [Notification Channel management](webrtc-notification-channel.yaml)
-  * **API not included on meta-release**
-  * This API definition provides functionality for a REST client, browser or native application, to establish notification channel to receive asynchronous notifications from MNO's IMS Network.
-    * [View main on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-notification-channel.yaml&nocors)
-    * [View main on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/main/code/API_definitions/webrtc-notification-channel.yaml)
 
 Detailed descriptions, diagrams and more information could be found at [API documentation](../../documentation/API_documentation/) section
 

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: WebRTC Call Handling API
+  title: WebRTC Call Handling
   description: |-
     ## 1. Introduction
 
@@ -165,7 +165,7 @@ info:
 
     Let's say that we are responding this session `0AEE1B58BAEEDA3EABA42B32EBB3DFE0DEAD`:
     ```
-    PUT /webrtc-call-handling/v0.2/sessions/0AEE1B58BAEEDA3EABA42B32EBB3DFE0DEAD
+    PUT /webrtc-call-handling/v0.2/sessions/0AEE1B58BAEEDA3EABA42B32EBB3DFE0DEAD/status
     {
         "status": "InProgress",
         "answer": {
@@ -207,15 +207,15 @@ info:
 
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   version: 0.3.0-rc.1
-  x-camara-commonalities: 0.5
+  x-camara-commonalities: 0.6
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/WebRTC
 servers:
-  - url: '{apiRoot}/webrtc-call-handling/v0.2'
+  - url: '{apiRoot}/webrtc-call-handling/v0.3rc1'
     variables:
       apiRoot:
         description: API root
@@ -293,6 +293,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MediaSessionInformation'
+        '400':
+          $ref: '#/components/responses/Generic400'
         '401':
           $ref: '#/components/responses/Generic401'
         '403':
@@ -324,6 +326,8 @@ paths:
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
+        '400':
+          $ref: '#/components/responses/Generic400'
         '401':
           $ref: '#/components/responses/Generic401'
         '403':
@@ -384,6 +388,8 @@ paths:
                   $ref: '#/components/examples/exampleSessionStatusResume'
         '204':
           description: Updated the session status (no content)
+        '400':
+          $ref: '#/components/responses/Generic400'
         '401':
           $ref: '#/components/responses/Generic401'
         '403':
@@ -508,12 +514,6 @@ components:
           type: string
           description: |-
             An inlined session description in SDP format [RFC4566].If XML syntax is used, the content of this element SHALL be embedded in a CDATA section
-    SessionNotification:
-      allOf:
-        - $ref: '#/components/schemas/MediaSessionInformation'
-      required:
-        - status
-        - mediaSessionId
     SessionStatus:
       type: string
       description: Provides the status of the media session. During the session creation, this attribute SHALL NOT be included in the request.

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -208,7 +208,7 @@ info:
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 0.2.0
+  version: 0.3.0-rc.1
   x-camara-commonalities: 0.5
 
 externalDocs:

--- a/code/API_definitions/webrtc-events-subscription.yaml
+++ b/code/API_definitions/webrtc-events-subscription.yaml
@@ -186,7 +186,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: vwip
+  version: 0.2.0-rc.1
   x-camara-commonalities: 0.5
 
 externalDocs:

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -616,7 +616,7 @@ components:
       properties:
         deviceId:
           type: string
-          example: 1qazxsw23edc
+          format: uuid
           description: |-
             The device-id of the client in UUID format. A unique identifier for
             the physical device where a registration is initiated. Generated
@@ -1479,7 +1479,7 @@ components:
           - org.camaraproject.webrtc-events.v0.session-invitation
         config:
           subscriptionDetail:
-            deviceId: "1qazxsw23edc"
+            deviceId: "7d444840-9dc0-11d1-b245-5ffdce74fad2"
             registrationId: "xsmcaum3z4zw4l0cu4w115m0"
           initialEvent: true
           subscriptionMaxEvents: 50
@@ -1501,7 +1501,7 @@ components:
           - org.camaraproject.webrtc-events.v0.session-status
         config:
           subscriptionDetail:
-            deviceId: "1qazxsw23edc"
+            deviceId: "7d444840-9dc0-11d1-b245-5ffdce74fad2"
             registrationId: "xsmcaum3z4zw4l0cu4w115m0"
             mediaSessionId: 0AEE1B58BAEEDA3EABA42B32EBB3DFE07E9CFF402EAF9EED8EF
           initialEvent: true

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: WebRTC Event Subscription
+  title: WebRTC Events
   description: |-
     ## 1. Introduction
 
@@ -187,13 +187,13 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.2.0-rc.1
-  x-camara-commonalities: 0.5
+  x-camara-commonalities: 0.6
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/WebRTC
 servers:
-  - url: "{apiRoot}/webrtc-events/v0.1"
+  - url: "{apiRoot}/webrtc-events/v0.2rc1"
     variables:
       apiRoot:
         default: http://localhost:9091
@@ -1406,7 +1406,7 @@ components:
     Generic429:
       description: Too Many Requests
       headers:
-        X-Correlator:
+        x-correlator:
           $ref: "#/components/headers/x-correlator"
       content:
         application/json:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -294,8 +294,7 @@ components:
       properties:
         deviceId:
           type: string
-          pattern: ^[a-zA-Z0-9-]{0,256}$
-          example: "7d444840-9dc0-11d1-b245-5ffdce74fad2"
+          pattern: uuid
           description: |-
             The deviceId of the client in UUID format. A unique identifier for
             the physical device where a registration is initiated. Generated

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -111,7 +111,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: vwip
+  version: 0.3.0-rc.1
   x-camara-commonalities: 0.5
 
 externalDocs:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: WebRTC Registration Service API
+  title: WebRTC Registration Service
   description: |-
     ## 1. Introduction
     This API provides the API consumer with the capabilities to manage
@@ -110,15 +110,15 @@ info:
 
   license:
     name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.3.0-rc.1
-  x-camara-commonalities: 0.5
+  x-camara-commonalities: 0.6
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/WebRTC
 servers:
-  - url: '{apiRoot}/webrtc-registration/v0.2'
+  - url: '{apiRoot}/webrtc-registration/v0.3rc1'
     description: APIs to manage device registration and connection
     variables:
       apiRoot:
@@ -294,6 +294,8 @@ components:
       properties:
         deviceId:
           type: string
+          pattern: ^[a-zA-Z0-9-]{0,256}$
+          example: "7d444840-9dc0-11d1-b245-5ffdce74fad2"
           description: |-
             The deviceId of the client in UUID format. A unique identifier for
             the physical device where a registration is initiated. Generated

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -5,16 +5,16 @@ The test plan has to be enhanced
 
 WebRTC Registration
 
-* webrtc-registration-createSession.feature
-* webrtc-registration-updateSession.feature
-* webrtc-registration-deleteSession.feature
+* webrtc-registration-createRegistration.feature
+* webrtc-registration-updateRegistration.feature
+* webrtc-registration-deleteRegistration.feature
 
 WebRTC Call Handling
 
 * webrtc-call-handling-createSession.feature
 * webrtc-call-handling-getSession.feature
 * webrtc-call-handling-deleteSession.feature
-* webrtc-call-handling-updateSession.feature
+* webrtc-call-handling-updateSessionStatus.feature
 
 WebRTC Events
 

--- a/code/Test_definitions/webrtc-call-handling-createSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-createSession.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation createSession
+Feature: CAMARA WebRTC Call Handling, v0.3.0-rc.1 - Operation createSession
 
   Background: Common createSession setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.2/sessions"                                                              |
+    And the resource "/webrtc-call-handling/v0.3rc1/sessions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-call-handling-deleteSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-deleteSession.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation deleteSession
+Feature: CAMARA WebRTC Call Handling, v0.3.0-rc.1 - Operation deleteSession
 
   Background: Common deleteSession setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.2/sessions/{mediaSessionId}"                                                              |
+    And the resource "/webrtc-call-handling/v0.3rc1/sessions/{mediaSessionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-call-handling-deleteSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-deleteSession.feature
@@ -38,10 +38,10 @@ Feature: CAMARA WebRTC Call Handling, v0.3.0-rc.1 - Operation deleteSession
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_call_handling_getSession_400.2_empty_request
+  @webrtc_call_handling_deleteSession_400.2_empty_request
   Scenario: Empty object as request path
     Given the path parameter "mediaSessionId" is set to ""
-    When the HTTP "GET" request is sent
+    When the HTTP "DELETE" request is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"

--- a/code/Test_definitions/webrtc-call-handling-getSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-getSession.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation getSession
+Feature: CAMARA WebRTC Call Handling, v0.3.0-rc.1 - Operation getSession
 
   Background: Common getSession setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.2/sessions/{mediaSessionId}"                                                              |
+    And the resource "/webrtc-call-handling/v0.3rc1/sessions/{mediaSessionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-call-handling-updateSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-updateSession.feature
@@ -1,25 +1,25 @@
-Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation updateSession
+Feature: CAMARA WebRTC Call Handling, v0.3.0-rc.1 - Operation updateSessionStatus
 
-  Background: Common updateSession setup
+  Background: Common updateSessionStatus setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.2/sessions/{mediaSessionId}"                                                              |
+    And the resource "/webrtc-call-handling/v0.3rc1/sessions/{mediaSessionId}/status"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "mediaSessionId" is set by default to a existing register session
 
-  @webrtc_call_handling_updateSession_01_generic_success_scenario
+  @webrtc_call_handling_updateSessionStatus_01_generic_success_scenario
   Scenario: Update the status of the voice-video session
     Given an existing voice-video session with "mediaSessionId" as "0AEE1B58BAEEDA3EABA42B32EBB3DFE07E9CFF402EAF9EED8EF"
     And the path parameter "mediaSessionId" is set to the value for that voice-video session
-    When the client sends a PUT request to "/sessions/0AEE1B58BAEEDA3EABA42B32EBB3DFE07E9CFF402EAF9EED8EF"
+    When the client sends a PUT request to "/sessions/0AEE1B58BAEEDA3EABA42B32EBB3DFE07E9CFF402EAF9EED8EF/status"
     Then the response status code should be 200
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/MediaSessionInformation"
 
   # Error scenarios
 
-  @webrtc_call_handling_updateSession_404_session_not_found
+  @webrtc_call_handling_updateSessionStatus_404_session_not_found
   Scenario: Session identifier cannot be matched to an existing call
     Given the path parameter "mediaSessionId" is compliant with the parameter schema but does not identify a valid session
     When the HTTP "PUT" request is sent
@@ -30,7 +30,7 @@ Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation updateSession
 
   # Generic 400 errors
 
-  @webrtc_call_handling_updateSession_400.1_no_request_body
+  @webrtc_call_handling_updateSessionStatus_400.1_no_request_body
   Scenario: Missing request path
     Given the path parameter "mediaSessionId" is not included
     When the HTTP "PUT" request is sent
@@ -39,7 +39,7 @@ Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation updateSession
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_call_handling_updateSession_400.2_empty_request_body
+  @webrtc_call_handling_updateSessionStatus_400.2_empty_request_body
   Scenario: Empty object as request path
     Given the path parameter "mediaSessionId" set to ""
     When the HTTP "PUT" request is sent
@@ -50,7 +50,7 @@ Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation updateSession
 
   # Generic 401 errors
 
-  @webrtc_call_handling_updateSession_401.1_no_authorization_header
+  @webrtc_call_handling_updateSessionStatus_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And the path parameter "mediaSessionId" is valid
@@ -60,7 +60,7 @@ Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation updateSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_call_handling_updateSession_401.2_expired_access_token
+  @webrtc_call_handling_updateSessionStatus_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And the path parameter "mediaSessionId" is valid
@@ -70,7 +70,7 @@ Feature: CAMARA WebRTC Call Handling, v0.2.0 - Operation updateSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_call_handling_updateSession_401.3_invalid_access_token
+  @webrtc_call_handling_updateSessionStatus_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
     And the path parameter "mediaSessionId" is valid

--- a/code/Test_definitions/webrtc-events-createSubscription.feature
+++ b/code/Test_definitions/webrtc-events-createSubscription.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.1.0 - Operation createSubscription
+Feature: CAMARA WebRTC Events, v0.2.0-rc.1 - Operation createSubscription
 
   Background: Common createSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-events/v0.1/subscriptions"                                                              |
+    And the resource "/webrtc-events/v0.2rc1/subscriptions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-createSubscription.feature
+++ b/code/Test_definitions/webrtc-events-createSubscription.feature
@@ -22,7 +22,7 @@ Feature: CAMARA WebRTC Events, v0.2.0-rc.1 - Operation createSubscription
         ],
         "config": {
           "subscriptionDetail": {
-            "deviceId": "1qazxsw23edc",
+            "deviceId": "7d444840-9dc0-11d1-b245-5ffdce74fad2",
             "registrationId": "xsmcaum3z4zw4l0cu4w115m0"
           },
           "initialEvent": true,

--- a/code/Test_definitions/webrtc-events-deleteSubscription.feature
+++ b/code/Test_definitions/webrtc-events-deleteSubscription.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.1.0 - Operation deleteSubscription
+Feature: CAMARA WebRTC Events, v0.2.0-rc.1 - Operation deleteSubscription
 
   Background: Common deleteSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.1/subscriptions/{subscriptionId}"                                                              |
+    And the resource "/webrtc-call-handling/v0.2rc1/subscriptions/{subscriptionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-deleteSubscription.feature
+++ b/code/Test_definitions/webrtc-events-deleteSubscription.feature
@@ -2,7 +2,7 @@ Feature: CAMARA WebRTC Events, v0.2.0-rc.1 - Operation deleteSubscription
 
   Background: Common deleteSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.2rc1/subscriptions/{subscriptionId}"                                                              |
+    And the resource "/webrtc-events/v0.2rc1/subscriptions/{subscriptionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-getListSubscriptions.feature
+++ b/code/Test_definitions/webrtc-events-getListSubscriptions.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.1.0 - Operation getListSubscriptions
+Feature: CAMARA WebRTC Events, v0.2.0-rc.1 - Operation getListSubscriptions
 
   Background: Common getListSubscriptions setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-events/v0.1/subscriptions"                                                              |
+    And the resource "/webrtc-events/v0.2rc1/subscriptions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-getSubscription.feature
+++ b/code/Test_definitions/webrtc-events-getSubscription.feature
@@ -2,7 +2,7 @@ Feature: CAMARA WebRTC Events, v0.2.0-rc.1 - Operation getSubscription
 
   Background: Common getSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.2rc1/subscriptions/{subscriptionId}"                                                              |
+    And the resource "/webrtc-events/v0.2rc1/subscriptions/{subscriptionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-getSubscription.feature
+++ b/code/Test_definitions/webrtc-events-getSubscription.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.1.0 - Operation getSubscription
+Feature: CAMARA WebRTC Events, v0.2.0-rc.1 - Operation getSubscription
 
   Background: Common getSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.1/subscriptions/{subscriptionId}"                                                              |
+    And the resource "/webrtc-call-handling/v0.2rc1/subscriptions/{subscriptionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-registration-createRegistration.feature
+++ b/code/Test_definitions/webrtc-registration-createRegistration.feature
@@ -14,7 +14,7 @@ Feature: CAMARA WebRTC Registration, v0.3.0-rc.1 - Operation createRegistration
     When the client sends a POST request to "/sessions" with the following payload:
       """
       {
-        "deviceId": "1qazxsw23edc"
+        "deviceId": "7d444840-9dc0-11d1-b245-5ffdce74fad2"
       }
       """
     Then the response status code should be 200

--- a/code/Test_definitions/webrtc-registration-createRegistration.feature
+++ b/code/Test_definitions/webrtc-registration-createRegistration.feature
@@ -1,15 +1,15 @@
-Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
+Feature: CAMARA WebRTC Registration, v0.3.0-rc.1 - Operation createRegistration
 
-  Background: Common createSession setup
+  Background: Common createRegistration setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-registration/v0.2/sessions"                                                              |
+    And the resource "/webrtc-registration/v0.3rc1/sessions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/regSessionRequest"
     # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
-
-  @webrtc_registration_createSession_01_generic_success_scenario
+ 
+  @webrtc_registration_createRegistration_01_generic_success_scenario
   Scenario: Create a new registration session
     When the client sends a POST request to "/sessions" with the following payload:
       """
@@ -25,7 +25,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
 
   # Generic 400 errors
 
-  @webrtc_registration_createSession_400.1_no_request_body
+  @webrtc_registration_createRegistration_400.1_no_request_body
   Scenario: Missing request body
     Given the request body is not included
     When the HTTP "POST" request is sent
@@ -34,7 +34,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_createSession_400.2_empty_request_body
+  @webrtc_registration_createRegistration_400.2_empty_request_body
   Scenario: Empty object as request body
     Given the request body is set to "{}"
     When the HTTP "POST" request is sent
@@ -45,7 +45,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
 
   # Generic 401 errors
 
-  @webrtc_registration_createSession_401.1_no_authorization_header
+  @webrtc_registration_createRegistration_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And the request body is set to a valid request body
@@ -55,7 +55,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_createSession_401.2_expired_access_token
+  @webrtc_registration_createRegistration_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And the request body is set to a valid request body
@@ -65,7 +65,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_createSession_401.3_invalid_access_token
+  @webrtc_registration_createRegistration_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
     And the request body is set to a valid request body

--- a/code/Test_definitions/webrtc-registration-deleteRegsitartionById.feature
+++ b/code/Test_definitions/webrtc-registration-deleteRegsitartionById.feature
@@ -1,24 +1,24 @@
-Feature: CAMARA WebRTC Registration, v0.2.0 - Operation deleteSession
+Feature: CAMARA WebRTC Registration, v0.3.0-rc.1 - Operation deleteRegistrationById
 
-  Background: Common deleteSession setup
+  Background: Common deleteRegistrationById setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-registration/v0.2/sessions/{registrationId}"                                                              |
+    And the resource "/webrtc-registration/v0.3rc1/sessions/{registrationId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "registrationId" is set by default to a existing register session
  
-  @webrtc_registration_deleteSession_01_generic_success_scenario
+  @webrtc_registration_deleteRegistrationById_01_generic_success_scenario
   Scenario: Delete an existing registration session
     Given an existing registration session with "registrationId" as "existing-session-id"
-    When the client sends a DELETE request to "/registrations/existing-session-id"
+    When the client sends a DELETE request to "/sessions/existing-session-id"
     Then the response status code should be 204
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the registration session should no longer exist
 
   # Error scenarios
 
-  @webrtc_registration_deleteSession_404_session_not_found
+  @webrtc_registration_deleteRegistrationById_404_session_not_found
   Scenario: Session identifier cannot be matched to a device
     Given the path parameter "registrationId" is compliant with the parameter schema but does not identify a valid session
     When the HTTP "DELETE" request is sent
@@ -29,7 +29,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation deleteSession
 
   # Generic 400 errors
 
-  @webrtc_registration_deleteSession_400.1_no_request
+  @webrtc_registration_deleteRegistrationById_400.1_no_request
   Scenario: Missing request path
     Given the path parameter "registrationId" is not included
     When the HTTP "DELETE" request is sent
@@ -49,7 +49,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation deleteSession
 
   # Generic 401 errors
 
-  @webrtc_registration_deleteSession_401.1_no_authorization_header
+  @webrtc_registration_deleteRegistrationById_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And the path parameter "registrationId" is valid
@@ -59,7 +59,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation deleteSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_deleteSession_401.2_expired_access_token
+  @webrtc_registration_deleteRegistrationById_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And the path parameter "registrationId" is valid
@@ -69,7 +69,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation deleteSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_deleteSession_401.3_invalid_access_token
+  @webrtc_registration_deleteRegistrationById_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
     And the path parameter "registrationId" is valid

--- a/code/Test_definitions/webrtc-registration-deleteRegsitartionById.feature
+++ b/code/Test_definitions/webrtc-registration-deleteRegsitartionById.feature
@@ -38,10 +38,10 @@ Feature: CAMARA WebRTC Registration, v0.3.0-rc.1 - Operation deleteRegistrationB
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_getSession_400.2_empty_request
+  @webrtc_registration_deleteRegistration_400.2_empty_request
   Scenario: Empty object as request path
     Given the path parameter "registrationId" is set to ""
-    When the HTTP "GET" request is sent
+    When the HTTP "DELETE" request is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"

--- a/code/Test_definitions/webrtc-registration-updateRegistrationById.feature
+++ b/code/Test_definitions/webrtc-registration-updateRegistrationById.feature
@@ -1,14 +1,14 @@
-Feature: CAMARA WebRTC Registration, v0.2.0 - Operation updateSession
+Feature: CAMARA WebRTC Registration, v0.3.0-rc.1 - Operation updateRegistrationById
 
-  Background: Common updateSession setup
+  Background: Common updateRegistrationById setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-registration/v0.2/sessions/{registrationId}"                                                              |
+    And the resource "/webrtc-registration/v0.3rc1/sessions/{registrationId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "registrationId" is set by default to a existing register session
  
-  @webrtc_registration_updateSession_01_generic_success_scenario
+  @webrtc_registration_updateRegistrationById_01_generic_success_scenario
   Scenario: Update an existing registration session
     Given an existing registration session with "registrationId" as "existing-session-id"
     And the path parameter "registrationId" is set to the value for that register session
@@ -18,7 +18,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation updateSession
 
   # Error scenarios
 
-  @webrtc_registration_updateSession_404_session_not_found
+  @webrtc_registration_updateRegistrationById_404_session_not_found
   Scenario: Session identifier cannot be matched to an existing call
     Given the path parameter "registrationId" is compliant with the parameter schema but does not identify a valid session
     When the HTTP "PUT" request is sent
@@ -29,7 +29,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation updateSession
 
   # Generic 400 errors
 
-  @webrtc_registration_updateSession_400.1_no_request_body
+  @webrtc_registration_updateRegistrationById_400.1_no_request_body
   Scenario: Missing request path
     Given the path parameter "registrationId" is not included
     When the HTTP "PUT" request is sent
@@ -38,7 +38,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation updateSession
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_updateSession_400.2_empty_request_body
+  @webrtc_registration_updateRegistrationById_400.2_empty_request_body
   Scenario: Empty object as request path
     Given the path parameter "registrationId" set to ""
     When the HTTP "PUT" request is sent
@@ -49,7 +49,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation updateSession
 
   # Generic 401 errors
 
-  @webrtc_registration_updateSession_401.1_no_authorization_header
+  @webrtc_registration_updateRegistrationById_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And the path parameter "registrationId" is valid
@@ -59,7 +59,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation updateSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_updateSession_401.2_expired_access_token
+  @webrtc_registration_updateRegistrationById_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And the path parameter "registrationId" is valid
@@ -69,7 +69,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation updateSession
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @webrtc_registration_updateSession_401.3_invalid_access_token
+  @webrtc_registration_updateRegistrationById_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
     And the path parameter "registrationId" is valid

--- a/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
@@ -4,9 +4,9 @@ Checklist for webrtc-call-handling v0.2.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
-|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-call-handling.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   Y   | r2.3 |
-|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   Y   | r2.3 |
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   InProgress   | [link](/code/API_definitions/webrtc-call-handling.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   |   |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
@@ -16,4 +16,4 @@ Checklist for webrtc-call-handling v0.2.0 in r1.2
 | 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |
 | 11 | Change log updated                           |   M   |   M   |   M   |   M   |   Y   | [link](/CHANGELOG.md) |
 | 12 | Previous public release was certified        |   O   |   O   |   O   |   M   |   N   |   |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [wiki link](https://lf-camaraproject.atlassian.net/wiki/xxx) |
+| 13 | API description (for marketing)              |   O   |   O   |   M   |   M   |   Y   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14560817/WebRTC) |

--- a/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API WebRTC Call Handling
 
-Checklist for webrtc-call-handling v0.3.0 in r2.1
+Checklist for webrtc-call-handling v0.3.0-rc.1 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|

--- a/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-call-handling-API-Readiness-Checklist.md
@@ -1,12 +1,12 @@
 # API WebRTC Call Handling
 
-Checklist for webrtc-call-handling v0.2.0 in r1.2
+Checklist for webrtc-call-handling v0.3.0 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
-|  1 | API definition                               |   M   |   M   |   M   |   M   |   InProgress   | [link](/code/API_definitions/webrtc-call-handling.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
-|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-call-handling.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   Y   | r3.2 |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   Y   | r3.2 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   |   |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API WebRTC events
 
-Checklist for webrtc-events v0.2.0 in r2.1
+Checklist for webrtc-events v0.2.0-rc.1 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -4,9 +4,9 @@ Checklist for webrtc-events v0.2.0-rc.1 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
-|  1 | API definition                               |   M   |   M   |   M   |   M   |   InProgress   | [link](/code/API_definitions/webrtc-events.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
-|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-events.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   Y   | r3.2 |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   Y   | r3.2 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   |   |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API WebRTC events
 
-Checklist for webrtc-events v0.1.0 in r1.2
+Checklist for webrtc-events v0.2.0 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|

--- a/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-events-API-Readiness-Checklist.md
@@ -4,9 +4,9 @@ Checklist for webrtc-events v0.1.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
-|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-events.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   Y   | r2.3 |
-|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   Y   | r2.3 |
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   InProgress   | [link](/code/API_definitions/webrtc-events.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   |   |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
@@ -16,4 +16,4 @@ Checklist for webrtc-events v0.1.0 in r1.2
 | 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |
 | 11 | Change log updated                           |   M   |   M   |   M   |   M   |   Y   | [link](/CHANGELOG.md) |
 | 12 | Previous public release was certified        |   O   |   O   |   O   |   M   |   N   |   |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [wiki link](https://lf-camaraproject.atlassian.net/wiki/xxx) |
+| 13 | API description (for marketing)              |   O   |   O   |   M   |   M   |   Y   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14560817/WebRTC) |

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API WebRTC Registration
 
-Checklist for webrtc-registration v0.2.0 in r1.2
+Checklist for webrtc-registration v0.3.0 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API WebRTC Registration
 
-Checklist for webrtc-registration v0.3.0 in r2.1
+Checklist for webrtc-registration v0.3.0-rc.1 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -4,9 +4,9 @@ Checklist for webrtc-registration v0.3.0-rc.1 in r2.1
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
-|  1 | API definition                               |   M   |   M   |   M   |   M   |   InProgress   | [link](/code/API_definitions/webrtc-registration.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
-|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-registration.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   Y   | r3.2 |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   Y   | r3.2 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   |   |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |

--- a/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/webrtc-registration-API-Readiness-Checklist.md
@@ -4,9 +4,9 @@ Checklist for webrtc-registration v0.2.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
-|  1 | API definition                               |   M   |   M   |   M   |   M   |   Y   | [link](/code/API_definitions/webrtc-registration.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   Y   | r2.3 |
-|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   Y   | r2.3 |
+|  1 | API definition                               |   M   |   M   |   M   |   M   |   InProgress   | [link](/code/API_definitions/webrtc-registration.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
+|  3 | Guidelines from ICM applied                  |   O   |   M   |   M   |   M   |   InProgress   | r3.2 |
 |  4 | API versioning convention applied            |   M   |   M   |   M   |   M   |   Y   |   |
 |  5 | API documentation                            |   M   |   M   |   M   |   M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |   O   |   O   |   M   |   N   |   |
@@ -16,4 +16,4 @@ Checklist for webrtc-registration v0.2.0 in r1.2
 | 10 | API release numbering convention applied     |   M   |   M   |   M   |   M   |   Y   |   |
 | 11 | Change log updated                           |   M   |   M   |   M   |   M   |   Y   | [link](/CHANGELOG.md) |
 | 12 | Previous public release was certified        |   O   |   O   |   O   |   M   |   N   |   |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [wiki link](https://lf-camaraproject.atlassian.net/wiki/xxx) |
+| 13 | API description (for marketing)              |   O   |   O   |   M   |   M   |   Y   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14560817/WebRTC) |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

* Fall 2025 meta-release candidate

#### Which issue(s) this PR fixes:

Fixes #82 

#### Special notes for reviewers:

This PR includes all changes from main.

#### Changelog input

```
 release-note
Updated README with latest links
Updated CHANGELOG with release upgrades
- webrtc-registration
fix: Updated deviceId format, examples and tests
- webrtc-call-handling
fix: Added 400 error response
- webrtc-events
fix: Updated deviceId format, examples and tests
```

#### Additional documentation 

This section can be blank.

```
docs
Updated API-Readiness with Wiki link and ICM & COMMS new release
```
