### PR TITLE
Updated CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @stroncoso-quobis @sushanthmavenir @pradeepachar-mavenir
+* @stroncoso-quobis @pradeepachar-mavenir @deepakjaiswal1
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

To improve engagement on the subproject and update members with write access to the repo.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for reviewers:

Agreed on meeting 20250-07-15.
- Added Deepak Jaiswal from T-Mobile to the list of code owners, 
- Removed Susthanth from Mavenir as it was agreed.

Check notes at https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/169115649/2025-07-15+WebRTC+Minutes

#### Changelog input

```
 release-note
Updated CODEOWNERS
```

#### Additional documentation 

n/a