### PR TITLE
fix: registrationId became mandatory on registration response

### DIFF
--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -320,6 +320,8 @@ components:
               `registrationExpireTime` in the response.
     regSessionResponse:
       type: object
+      required:
+        - registrationId
       properties:
         regInfo:
           $ref: '#/components/schemas/RegistrationInformation'

--- a/code/Test_definitions/webrtc-registration-createSession.feature
+++ b/code/Test_definitions/webrtc-registration-createSession.feature
@@ -8,7 +8,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/regSessionRequest"
     # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
- 
+
   @webrtc_registration_createSession_01_generic_success_scenario
   Scenario: Create a new registration session
     When the client sends a POST request to "/sessions" with the following payload:
@@ -19,7 +19,7 @@ Feature: CAMARA WebRTC Registration, v0.2.0 - Operation createSession
       """
     Then the response status code should be 200
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body should contain a "registrationId"
+    And the response body must contain a "registrationId"
 
   # Error scenarios
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug

#### What this PR does / why we need it:

As the `registrationId` is a required element for subsequents actions on the registration management, it is required to ensure that registration creation action includes that `regsitrationId` on the response.

#### Which issue(s) this PR fixes:

Fixes #81 

#### Special notes for reviewers:

Solution proposed by @teikuran at scoped issue

#### Changelog input

```
 release-note
fix: registrationId became mandatory on registration response
```

#### Additional documentation 

n/a
