### PR TITLE
fix: include data as mandatory on callback events

### DIFF
--- a/code/API_definitions/webrtc-events-subscription.yaml
+++ b/code/API_definitions/webrtc-events-subscription.yaml
@@ -850,7 +850,7 @@ components:
     ############################################
     MediaSession:
       description: |-
-        A prototype for Webrtc events. Used at `SessionStatusEvent` and `SessionInvitationEvent` schemas
+        A prototype for media session infomration on Webrtc events. Used as event data schemas for session updates.
       type: object
       required:
         - mediaSessionId
@@ -928,6 +928,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/MediaSession"
         - type: object
+          description: MediaSession information emitted on a EventSessionStatus event
           required:
             - status
 
@@ -935,10 +936,11 @@ components:
       allOf:
         - $ref: "#/components/schemas/MediaSession"
         - type: object
+          description: MediaSession information emitted on a EventSessionInvitation event
           required:
             - originatorAddress
             - receiverAddress
-      
+
     WrtcSDPDescriptor:
       type: object
       properties:


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Current webrt-events API version defined, as mandatory, fields inside the data object, not the data object itself, so this lead to an incorrect API representation.

Moreover, callback events must include data relevant to their use cases, so it is required to dive into the required data notified. In consequence, this PR tries to cover the data required on each specific event. 

#### Which issue(s) this PR fixes:

Fixes #84 

#### Special notes for reviewers:

Based on the solution purposed by @teikuran , with some addons:

- Events now include a data field as mandatory
- `EventRegistrationEnds` also requires now a data field
- This data depend on the event, so...
  - `MediaSessionInfonration` was renamed to prototype `MediaSession`, that requires `mediaSessionId`
  - And this prototype is then detailed per each event:
    - `MediaSessionStatusUpdate`, used by `EventSessionStatus` requires `status` field
    - `MediaSessionInvite`, used by `EventSessionInvitation` requires `originatorAddress` and `receiverAddress` fields

#### Changelog input

```
 release-note - webrtc-events
- fix: Updated mandatory fields per specific event data callback
```

#### Additional documentation 

n/a