### PR TITLE
fix API render links for r2.1 at CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Changelog since latest public r1.2
 
 - API definition **with inline documentation**:
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-call-handling.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-call-handling.yaml)
 
 ### Changes
@@ -79,9 +79,9 @@ Changelog since latest public r1.2
 ## WebRTC Events v0.2.0-rc.1
 
 - API definition **with inline documentation**:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-events.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r1.2/code/API_definitions/webrtc-events.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r1.2/code/API_definitions/webrtc-events.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-events.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/WebRTC/r2.1/code/API_definitions/webrtc-events.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/WebRTC/blob/r2.1/code/API_definitions/webrtc-events.yaml)
 
 ### Added
 * Added new event type `webrtc-events:org.camaraproject.webrtc-events.v0.registration-ends` to notify subscribers when a registration ends at PR [#83](https://github.com/camaraproject/WebRTC/pull/83)


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

API render should be included on changelog for all APIs
For swagger visualization, use local instance at `camaraproject.github.io`
Some links were incorrect due to the long list of manual changes at releasing process.

#### Which issue(s) this PR fixes:

Fixes #96 

#### Special notes for reviewers:

Release notes at [r2.1](https://github.com/camaraproject/WebRTC/releases/tag/r2.1) already included this changes.

#### Changelog input

```
 release-note
fix API render links for r2.1 at CHANGELOG
```

#### Additional documentation 

n/a