### PR TITLE
fix: status attribute required in session-invitation

### DIFF
--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -940,6 +940,7 @@ components:
           required:
             - originatorAddress
             - receiverAddress
+            - status
 
     WrtcSDPDescriptor:
       type: object


### PR DESCRIPTION
#### What type of PR is this?
- bug

#### What this PR does / why we need it:
The current WebRTC Events states that during session creation, the 'status' attribute should contain the value 'Initial', so this is propsed to make 'status' required for EventSessionInvitation.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #[99](https://github.com/camaraproject/WebRTC/issues/99)

#### Changelog input

```
 release-note - webrtc-events
- fix: Updated mandatory fields for EventSessionInvitation
```

#### Additional documentation 

n/a