### PR TITLE
Updated CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @stroncoso-quobis @pradeepachar-mavenir @deepakjaiswal1
+* @stroncoso-quobis @pradeepachar-mavenir @deepakjaiswal1 @teikuran
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -12,3 +12,4 @@
 | Vodafone | Ratna Ganeshanandan | ratnavf |
 | Orange | Benjamin Busvel | BenjaminBusvel |
 | Orange | Maxime Delon | maximedelon |
+| NTT | Tsuyoshi Takakura | teikuran |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

To improve engagement on the subproject and update members with write access to the repo.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for reviewers:

Agreed on meeting 20250-07-15.
* Added Tsuyoshi Takakura from NTT to the list of code owners,

Check notes at Wiki:
* https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/216203265/2025-08-26+WebRTC+Minutes

#### Changelog input

```
 release-note
Updated CODEOWNERS
```

#### Additional documentation 

n/a