### PR TITLE
fix: removing reason and sequenceNumber fields from MediaSessionInformation

### DIFF
--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -489,14 +489,6 @@ components:
             This element shall be included and set to true, if the session updates are received
             without SDP offer. This element indicates clients to send the offer.
           example: false
-        reason:
-          type: string
-          description: The description of the event that has happened within the session
-          example: 183 Progress
-        sequenceNumber:
-          type: integer
-          description: The sequence number of the notification sent to client
-          example: 345
     WrtcSDPDescriptor:
       type: object
       description: |-


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug



#### What this PR does / why we need it:
The `reason` and `sequenceNumber` fields in `MediaSessionInformation` schema are not used in  WebRTC Call Handling API; hence it is proposed to remove them. 

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #87 

#### Special notes for reviewers:



#### Changelog input

```
 release-note - webrtc-call-handling
- fix: removing reason and sequenceNumber fields from MediaSessionInformation
```

#### Additional documentation 

n/a
