### PR TITLE
Decoupling WebRTC-Events subscriptions from specific media session or registration

### DIFF
--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -13,7 +13,7 @@ info:
     registrations and sessions may occur.
 
     Instead of requiring separate subscriptions per registration (`registrationId`) or per session
-    (`sessionId`), event delivery is consolidated under the deviceId. This enables the client to
+    (`mediaSessionId`), event delivery is consolidated under the deviceId. This enables the client to
     receive all relevant notifications — such as new call invitations or session status updates —
     for any registration or session belonging to the same device.
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:

Since subscriptions to `org.camaraproject.webrtc-events.v0.session-invitation` and `org.camaraproject.webrtc-events.v0.session-status` events should be subscribed prior to registration, this PR changes them to not use registrationId. For the `org.camaraproject.webrtc-events.v0.session-status` event, it is possible to determine which call it is associated with from the mediaSessionId included in the callback. Therefore, this PR changes session-status event subscriptions to be linked per device using deviceId. For `org.camaraproject.webrtc-events.v0.registration-ends`, since the API Provider maintains the association between valid registrations and deviceId, this PR changes registration-ends event subscriptions to be linked per device using deviceId.

Based on the above, this PR removes registrationId and sessionId from WebrtcSubscriptionDetail and makes deviceId, which is always required for subscriptions, a "required" field.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #118

#### Changelog input

```
 release-note
- webrtc-events - fix: Decoupling WebRTC-Events subscriptions from specific media session or registration #126
```


