### PR TITLE
Fix issue #76: update WebRTC subscription examples and developer guidance

### DIFF
--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -222,6 +222,11 @@ paths:
         To subscribe and receive notifications about new calls, a
         `session-invitation` subscription is required using the `deviceId` related to a valid registration.
 
+        For WebRTC calling subscription scenarios, developers should not use
+        `initialEvent` or `subscriptionMaxEvents`. These attributes remain in
+        the schema for CAMARA compatibility, but they are not used by this API
+        for WebRTC calling subscriptions.
+
       operationId: createNotificationChannelSubscription
       parameters:
         - $ref: "#/components/parameters/x-correlator"
@@ -517,6 +522,11 @@ components:
         specifications.
 
         WebRTC specific event type attributes are included into `WebrtcSubscriptionDetail` schema.
+
+        For WebRTC calling subscriptions in this API, developers should use `subscriptionDetail`
+        and, optionally, `subscriptionExpireTime`. The predefined CAMARA attributes
+        `subscriptionMaxEvents` and `initialEvent` are kept for schema alignment and compatibility,
+        but they are not used for WebRTC calling subscription scenarios.
 
         Note: if a request is performed for several event type, all subscribed event will use same `config`
         parameters.
@@ -1418,7 +1428,7 @@ components:
         sinkCredential:
           credentialType: "ACCESSTOKEN"
           accessToken: "eyJ2ZXIiOiIxLjAiLCJ0eXAiOiJKV1QiL.."
-          accessTokenExpireUtc: "2024-12-06T14:37:56.147Z"
+          accessTokenExpiresUtc: "2024-12-06T14:37:56.147Z"
           accessTokenType: "bearer"
         types:
           - org.camaraproject.webrtc-events.v0.registration-ends
@@ -1435,8 +1445,8 @@ components:
         the client aware of registration status updates from the server.
         (i.e. when a REGISTRATION expires).
 
-        The provided example will be able to receive up to 50 calls until
-        subscription is cancelled via server or by configuration timeout. Check
+        The example uses `sinkCredential` for authenticated event delivery and
+        a `subscriptionExpireTime` to control the subscription lifetime. Check
         callback examples to check some possible events received:
 
         - New incoming call
@@ -1444,13 +1454,16 @@ components:
       value:
         protocol: HTTP
         sink: https://notificationServer.opentelco.com
+        sinkCredential:
+          credentialType: "ACCESSTOKEN"
+          accessToken: "eyJ2ZXIiOiIxLjAiLCJ0eXAiOiJKV1QiL.."
+          accessTokenExpiresUtc: "2024-12-06T14:37:56.147Z"
+          accessTokenType: "bearer"
         types:
           - org.camaraproject.webrtc-events.v0.session-invitation
         config:
           subscriptionDetail:
             deviceId: "7d444840-9dc0-11d1-b245-5ffdce74fad2"
-          initialEvent: true
-          subscriptionMaxEvents: 50
           subscriptionExpireTime: "2024-11-17T13:18:23.682Z"
     SESSION_SUBSCRIPTION:
       description: |-
@@ -1462,16 +1475,22 @@ components:
         This could be used to remotely control the call or to handle the async
         session establishment. For instance, updating the user interface for
         different statuses: InProgress, Ringing, Cancel, etc.
+
+        The example uses `sinkCredential` for authenticated event delivery and
+        a `subscriptionExpireTime` to control the subscription lifetime.
       value:
         protocol: HTTP
         sink: https://notificationServer.opentelco.com
+        sinkCredential:
+          credentialType: "ACCESSTOKEN"
+          accessToken: "eyJ2ZXIiOiIxLjAiLCJ0eXAiOiJKV1QiL.."
+          accessTokenExpiresUtc: "2024-12-06T14:37:56.147Z"
+          accessTokenType: "bearer"
         types:
           - org.camaraproject.webrtc-events.v0.session-status
         config:
           subscriptionDetail:
             deviceId: "7d444840-9dc0-11d1-b245-5ffdce74fad2"
-          initialEvent: true
-          subscriptionMaxEvents: 50
           subscriptionExpireTime: "2024-11-17T13:18:23.682Z"
     # Event examples
     NEW_SESSION_INCOMING:


### PR DESCRIPTION
## Summary
Addresses #76 by updating WebRTC subscription examples and adding developer clarification.

## Which issue(s) this PR fixes:

Fixes #76 

## Changes
- No change to Commonalities-aligned schema fields `subscriptionMaxEvents` and `initialEvent`
- Removed `subscriptionMaxEvents` and `initialEvent` from WebRTC calling subscription examples
- Added clarification that these attributes are not used for WebRTC calling subscription scenarios
- Added `sinkCredential` to the `session-invitation` and `session-status` subscription examples
- Fixed example field name from `accessTokenExpireUtc` to `accessTokenExpiresUtc`

## Notes
This PR keeps schema compatibility while making examples more representative for WebRTC calling subscriptions.