### PR TITLE
Reset API and test version information to wip (merge before other PRs)

### DIFF
--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -209,14 +209,14 @@ info:
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 0.3.0
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/WebRTC
 servers:
-  - url: '{apiRoot}/webrtc-call-handling/v0.3'
+  - url: '{apiRoot}/webrtc-call-handling/vwip'
     variables:
       apiRoot:
         description: API root

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -189,14 +189,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.2.0
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/WebRTC
 servers:
-  - url: "{apiRoot}/webrtc-events/v0.2"
+  - url: "{apiRoot}/webrtc-events/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -112,14 +112,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.3.0
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/WebRTC
 servers:
-  - url: '{apiRoot}/webrtc-registration/v0.3'
+  - url: '{apiRoot}/webrtc-registration/vwip'
     description: APIs to manage device registration and connection
     variables:
       apiRoot:

--- a/code/Test_definitions/webrtc-call-handling-createSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-createSession.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Call Handling, v0.3.0 - Operation createSession
+Feature: CAMARA WebRTC Call Handling, vwip - Operation createSession
 
   Background: Common createSession setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.3/sessions"                                                              |
+    And the resource "/webrtc-call-handling/vwip/sessions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-call-handling-deleteSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-deleteSession.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Call Handling, v0.3.0 - Operation deleteSession
+Feature: CAMARA WebRTC Call Handling, vwip - Operation deleteSession
 
   Background: Common deleteSession setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.3/sessions/{mediaSessionId}"                                                              |
+    And the resource "/webrtc-call-handling/vwip/sessions/{mediaSessionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-call-handling-getSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-getSession.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Call Handling, v0.3.0 - Operation getSession
+Feature: CAMARA WebRTC Call Handling, vwip - Operation getSession
 
   Background: Common getSession setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.3/sessions/{mediaSessionId}"                                                              |
+    And the resource "/webrtc-call-handling/vwip/sessions/{mediaSessionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-call-handling-updateSession.feature
+++ b/code/Test_definitions/webrtc-call-handling-updateSession.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Call Handling, v0.3.0 - Operation updateSessionStatus
+Feature: CAMARA WebRTC Call Handling, vwip - Operation updateSessionStatus
 
   Background: Common updateSessionStatus setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-call-handling/v0.3/sessions/{mediaSessionId}/status"                                                              |
+    And the resource "/webrtc-call-handling/vwip/sessions/{mediaSessionId}/status"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-createSubscription.feature
+++ b/code/Test_definitions/webrtc-events-createSubscription.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.2.0 - Operation createSubscription
+Feature: CAMARA WebRTC Events, vwip - Operation createSubscription
 
   Background: Common createSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-events/v0.2/subscriptions"                                                              |
+    And the resource "/webrtc-events/vwip/subscriptions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-deleteSubscription.feature
+++ b/code/Test_definitions/webrtc-events-deleteSubscription.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.2.0 - Operation deleteSubscription
+Feature: CAMARA WebRTC Events, vwip - Operation deleteSubscription
 
   Background: Common deleteSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-events/v0.2/subscriptions/{subscriptionId}"                                                              |
+    And the resource "/webrtc-events/vwip/subscriptions/{subscriptionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-getListSubscriptions.feature
+++ b/code/Test_definitions/webrtc-events-getListSubscriptions.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.2.0 - Operation getListSubscriptions
+Feature: CAMARA WebRTC Events, vwip - Operation getListSubscriptions
 
   Background: Common getListSubscriptions setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-events/v0.2/subscriptions"                                                              |
+    And the resource "/webrtc-events/vwip/subscriptions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-events-getSubscription.feature
+++ b/code/Test_definitions/webrtc-events-getSubscription.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Events, v0.2.0 - Operation getSubscription
+Feature: CAMARA WebRTC Events, vwip - Operation getSubscription
 
   Background: Common getSubscription setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-events/v0.2/subscriptions/{subscriptionId}"                                                              |
+    And the resource "/webrtc-events/vwip/subscriptions/{subscriptionId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-registration-createRegistration.feature
+++ b/code/Test_definitions/webrtc-registration-createRegistration.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Registration, v0.3.0 - Operation createRegistration
+Feature: CAMARA WebRTC Registration, vwip - Operation createRegistration
 
   Background: Common createRegistration setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-registration/v0.3/sessions"                                                              |
+    And the resource "/webrtc-registration/vwip/sessions"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-registration-deleteRegsitartionById.feature
+++ b/code/Test_definitions/webrtc-registration-deleteRegsitartionById.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Registration, v0.3.0 - Operation deleteRegistrationById
+Feature: CAMARA WebRTC Registration, vwip - Operation deleteRegistrationById
 
   Background: Common deleteRegistrationById setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-registration/v0.3/sessions/{registrationId}"                                                              |
+    And the resource "/webrtc-registration/vwip/sessions/{registrationId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/webrtc-registration-updateRegistrationById.feature
+++ b/code/Test_definitions/webrtc-registration-updateRegistrationById.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA WebRTC Registration, v0.3.0 - Operation updateRegistrationById
+Feature: CAMARA WebRTC Registration, vwip - Operation updateRegistrationById
 
   Background: Common updateRegistrationById setup
     Given an environment at "apiRoot"
-    And the resource "/webrtc-registration/v0.3/sessions/{registrationId}"                                                              |
+    And the resource "/webrtc-registration/vwip/sessions/{registrationId}"                                                              |
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Resets all version references in API definitions and test files on the main branch to work-in-progress (`wip`) versions. This is the standard post-release procedure that prepares the repository for the next development cycle and aligns with the CAMARA Release Workflow.

**Changes:**
- 3 API definitions: `info.version` → `wip`, server URL → `vwip`
- 11 test files: Feature headers → `vwip`, resource URLs → `vwip`

#### Which issue(s) this PR fixes:

Fixes #128

#### Special notes for reviewers:

Straightforward version reset. All changes are mechanical replacements of release version numbers with `wip`/`vwip`.

#### Changelog input

```
 release-note
N/A - version field maintenance only
```

#### Additional documentation

This section can be blank.

```
docs
N/A
```