### PR TITLE
fix: PascalCase convention for schemas names

### DIFF
--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -61,7 +61,7 @@ info:
     - **SDP**: Acronym for Session Description Protocol. The SDP is a format for
       describing multimedia communication sessions for the purposes of announcement
       and invitation.
-    - **WrtcSDPDescriptor**: Schema to include inside a JSON, a SDP body. You can
+    - **WrtcSdpDescriptor**: Schema to include inside a JSON, a SDP body. You can
       obtain an SDP for WebRTC calling using the WebRTC API provided by the browser
       or any other media library.
 
@@ -482,9 +482,9 @@ components:
         status:
           $ref: '#/components/schemas/SessionStatus'
         offer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         answer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         mediaSessionId:
           type: string
           description: >-
@@ -500,7 +500,7 @@ components:
             - EMERGENCY
         locationDetails:
           $ref: '#/components/schemas/LocationDetails'
-    WrtcSDPDescriptor:
+    WrtcSdpDescriptor:
       type: object
       description: |-
         **OFFER**: An inlined session description in SDP format [RFC4566].If XML syntax

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -968,9 +968,9 @@ components:
             - NotReachable
             - Busy
         offer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         answer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         mediaSessionId:
           type: string
           description: The media session ID created by the network. The mediaSessionId shall not be included in POST requests by the client, but must be included in the notifications from the network to client.
@@ -1000,7 +1000,7 @@ components:
             - receiverAddress
             - status
 
-    WrtcSDPDescriptor:
+    WrtcSdpDescriptor:
       type: object
       properties:
         sdp:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -149,7 +149,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/regSessionRequest'
+              $ref: '#/components/schemas/RegSessionRequest'
       responses:
         '200':
           description: Ok
@@ -159,7 +159,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/regSessionResponse'
+                $ref: '#/components/schemas/RegSessionResponse'
         '400':
           $ref: "#/components/responses/CreateSessionBadRequest400"
         '401':
@@ -202,7 +202,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/regSessionUpdate'
+              $ref: '#/components/schemas/RegSessionUpdate'
       responses:
         '200':
           description: Ok
@@ -212,7 +212,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/regSessionResponse'
+                $ref: '#/components/schemas/RegSessionResponse'
         '204':
           description: Updated the registration status (no content)
           headers:
@@ -288,7 +288,7 @@ components:
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-    regSessionRequest:
+    RegSessionRequest:
       type: object
       required:
         - deviceId
@@ -319,7 +319,7 @@ components:
             ▸ If the client omits this field, the server will set the expiry
               according to its own TTL policy and return the resulting
               `registrationExpireTime` in the response.
-    regSessionResponse:
+    RegSessionResponse:
       type: object
       required:
         - registrationId
@@ -341,7 +341,7 @@ components:
             and plan to refresh well in advance to avoid race conditions. A suggested margin is 120 seconds before expiry.
 
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-    regSessionUpdate:
+    RegSessionUpdate:
       type: object
       properties:
         registrationExpireTime:

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: webrtc-call-handling
     target_api_version: 0.4.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - stroncoso
       - pradeepachar-mavenir
@@ -42,7 +42,7 @@ apis:
       - teikuran
   - api_name: webrtc-events
     target_api_version: 0.3.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - stroncoso
       - pradeepachar-mavenir
@@ -50,7 +50,7 @@ apis:
       - teikuran
   - api_name: webrtc-registration
     target_api_version: 0.4.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - stroncoso
       - pradeepachar-mavenir


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:

Follow PascalCase convention for schemas naming


#### Which issue(s) this PR fixes:

Fixes #114 

#### Special notes for reviewers:

No behavior changes

#### Changelog input

```
 release-note
fix: PascalCase convention for schemas names
```

#### Additional documentation 

n/a