### PR TITLE
fix: set target_api_status to rc to match pre-release-rc release type

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: webrtc-call-handling
     target_api_version: 0.4.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - stroncoso
       - pradeepachar-mavenir
@@ -42,7 +42,7 @@ apis:
       - teikuran
   - api_name: webrtc-events
     target_api_version: 0.3.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - stroncoso
       - pradeepachar-mavenir
@@ -50,7 +50,7 @@ apis:
       - teikuran
   - api_name: webrtc-registration
     target_api_version: 0.4.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - stroncoso
       - pradeepachar-mavenir


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Sets `target_api_status: rc` for all three APIs in `release-plan.yaml` to match the intended `target_release_type: pre-release-rc`.

#### Which issue(s) this PR fixes:

Fixes #160

#### Special notes for reviewers:

No code or API changes — only the release plan declaration. After merge, release issue #155 will refresh to show consistent `rc` across release type and per-API rows.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.

```
docs

```