### PR TITLE
fix: Clarification on registrationExpireTime

### DIFF
--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -315,7 +315,12 @@ components:
 
               and initiate a refresh *before* `ttl` elapses (a safety margin
               of ~120 s is recommended).
-
+              
+            ▸ If the client includes this field, the server evaluates the
+              requested expiry against its local policy and may shorten (but
+              must not extend) the requested value. A requested duration exceeding
+              the operator's allowed limit is overridden by the server.
+              
             ▸ If the client omits this field, the server will set the expiry
               according to its own TTL policy and return the resulting
               `registrationExpireTime` in the response.

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -316,14 +316,20 @@ components:
               and initiate a refresh *before* `ttl` elapses (a safety margin
               of ~120 s is recommended).
               
-            ▸ If the client includes this field, the server evaluates the
-              requested expiry against its local policy and may shorten (but
-              must not extend) the requested value. A requested duration exceeding
-              the operator's allowed limit is overridden by the server.
+            ▸ If the client includes a value exceeding the operator's allowed maximum,
+              either an overridden value(per the server's local policy) is applied or
+              a 4xx error response is returned.
+              
+            ▸ If the client includes a value within the operator's allowed range, the
+              requested value is applied as-is.
+              
+            ▸ If the client includes a value below the operator's allowed minimum,
+              a 4xx error response is returned.
               
             ▸ If the client omits this field, the server will set the expiry
               according to its own TTL policy and return the resulting
               `registrationExpireTime` in the response.
+              
     regSessionResponse:
       type: object
       required:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -315,21 +315,21 @@ components:
 
               and initiate a refresh *before* `ttl` elapses (a safety margin
               of ~120 s is recommended).
-              
+
             ▸ If the client includes a value exceeding the operator's allowed maximum,
               either an overridden value(per the server's local policy) is applied or
               a 4xx error response is returned.
-              
+
             ▸ If the client includes a value within the operator's allowed range, the
               requested value is applied as-is.
-              
+
             ▸ If the client includes a value below the operator's allowed minimum,
               a 4xx error response is returned.
-              
+
             ▸ If the client omits this field, the server will set the expiry
               according to its own TTL policy and return the resulting
               `registrationExpireTime` in the response.
-              
+
     regSessionResponse:
       type: object
       required:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -305,7 +305,7 @@ components:
           format: date-time
           description: |-
             Optional **absolute** expiry moment for this registration.
-            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must include a time offset.
 
             ▸ **Devices without a trustworthy clock** (e.g. Wi-Fi-only tablets
               or other non-SIM hardware) SHOULD treat the value as an
@@ -317,18 +317,17 @@ components:
               of ~120 s is recommended).
 
             ▸ If the client includes a value exceeding the operator's allowed maximum,
-              either an overridden value(per the server's local policy) is applied or
-              a 4xx error response is returned.
+              the server caps the value and returns the authoritative expiry in `expiresAt`.
 
             ▸ If the client includes a value within the operator's allowed range, the
               requested value is applied as-is.
 
             ▸ If the client includes a value below the operator's allowed minimum,
-              a 4xx error response is returned.
+              a `400 - OUT_OF_RANGE` error response is returned.
 
             ▸ If the client omits this field, the server will set the expiry
-              according to its own TTL policy and return the resulting
-              `registrationExpireTime` in the response.
+              according to its own TTL policy and return the authoritative expiry in
+              `expiresAt` in the response.
 
     regSessionResponse:
       type: object
@@ -360,13 +359,20 @@ components:
           format: date-time
           description: |-
             Optional **absolute** UTC timestamp that *requests* a new expiry.
-            The server will honour the value only if it is **later than the
-            operator's minimum TTL** and **earlier than operator maximum TTL**;
-            otherwise it falls back to its own policy (see refresh algorithm
-            above).
+            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must include a time offset.
 
-            If omitted, the server always extends the expiry by its configured
-            TTL, measured from the moment the refresh is received.
+            If the client includes a value exceeding the operator's allowed maximum,
+            the server caps the value and returns the authoritative expiry in `expiresAt`.
+
+            If the client includes a value within the operator's allowed range, the
+            requested value is applied as-is.
+
+            If the client includes a value below the operator's allowed minimum,
+            a `400 - OUT_OF_RANGE` error response is returned.
+
+            If the client omits this field, the server extends the expiry
+            according to its own TTL policy and returns the authoritative
+            expiry in `expiresAt`.
 
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
     RegistrationStatus:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* documentation


#### What this PR does / why we need it:
To address following issues:

The current specification for the webrtc-registration may need further clarification regarding how the GW handles the 'registrationExpireTime' when it is explicitly provided by the API consumer.

While the description for regSessionRequest states that if the client omits this field, the server sets the expiry according to its own TTL policy, there is no description about how the GW handles the registrationExpireTime when it is explicitly provided by the API consumer e.g., whehter the GW should strictly follow or ignore a client-provided value that exceeds operator limits.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #144 

#### Changelog input

```
  release-note - webrtc-registration
- fix: Clarification on registrationExpireTime
```