### PR TITLE
fix: Clarification on registration expiration

### DIFF
--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -78,8 +78,7 @@ info:
     repository.
 
     **Behaviour on registration expiration:**
-    - Ongoing media sessions MAY be terminated when the registration expires
-      based on operator's policy.
+    - Ongoing media sessions MAY be terminated when the registration expires.
     - Event subscriptions created via webrtc-events API are not affected.
 
     # Authorization and authentication

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -78,8 +78,8 @@ info:
     repository.
 
     **Behaviour on registration expiration:**
-    - Whether ongoing media sessions are terminated when the registration expires
-      is operator-dependent.
+    - Ongoing media sessions MAY be terminated when the registration expires
+      based on operator's policy.
     - Event subscriptions created via webrtc-events API are not affected.
 
     # Authorization and authentication

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -77,6 +77,11 @@ info:
     Check for extra details on each of these APIs already present on the WebRTC
     repository.
 
+    **Behaviour on registration expiration:**
+    - Whether ongoing media sessions are terminated when the registration expires
+      is operator-dependent.
+    - Event subscriptions created via webrtc-events API are not affected.
+
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* documentation

#### What this PR does / why we need it:
To address following issues:
The current specification defines that once a registration expires, initiating new incoming or outgoing calls is no longer possible. However, the expected behavior for existing active resources at the moment of expiration is not documented.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #146 

#### Changelog input

```
 release-note
- fix: Clarification on registrationExpireTime](fix: Clarification on registration expiration
```