### PR TITLE
feat: add GET /sessions and correct POST 201 response

### DIFF
--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -137,80 +137,80 @@ tags:
 paths:
   /sessions:
     get:
-          tags:
-            - Registration
-          summary: Retrieve all registrations for a device
+      tags:
+        - Registration
+      summary: Retrieve all registrations for a device
+      description: |-
+        Retrieve all active registrations associated with a given `deviceId`.
+
+        This endpoint allows an API consumer to recover registration state
+        after a network disconnection or application restart, where the
+        `registrationId` has been lost but the `deviceId` is known.
+
+        Returns an empty array if no active registrations exist for the
+        given `deviceId`. It is not possible to retrieve registrations
+        belonging to other devices.
+      operationId: getRegistrationsByDeviceId
+      parameters:
+        - $ref: '#/components/parameters/x-correlator'
+        - name: deviceId
+          in: query
+          required: true
           description: |-
-            Retrieve all active registrations associated with a given `deviceId`.
-
-            This endpoint allows an API consumer to recover registration state
-            after a network disconnection or application restart, where the
-            `registrationId` has been lost but the `deviceId` is known.
-
-            Returns an empty array if no active registrations exist for the
-            given `deviceId`. It is not possible to retrieve registrations
-            belonging to other devices.
-          operationId: getRegistrationsByDeviceId
-          parameters:
-            - $ref: '#/components/parameters/x-correlator'
-            - name: deviceId
-              in: query
-              required: true
-              description: |-
-                The deviceId of the client in UUID format. Only registrations
-                associated with this deviceId will be returned.
+            The deviceId of the client in UUID format. Only registrations
+            associated with this deviceId will be returned.
+          schema:
+            type: string
+            format: uuid
+      security:
+        - openId:
+            - webrtc-registration:sessions:read
+      responses:
+        '200':
+          description: |-
+            List of active registrations for the given deviceId.
+            Returns an empty array if no active registrations exist.
+          headers:
+            x-correlator:
+              $ref: '#/components/headers/x-correlator'
+          content:
+            application/json:
               schema:
-                type: string
-                format: uuid
-          security:
-            - openId:
-                - webrtc-registration:sessions:read
-          responses:
-            '200':
-              description: |-
-                List of active registrations for the given deviceId.
-                Returns an empty array if no active registrations exist.
-              headers:
-                x-correlator:
-                  $ref: '#/components/headers/x-correlator'
-              content:
-                application/json:
-                  schema:
-                    type: array
-                    maxItems: 10
-                    items:
-                      $ref: '#/components/schemas/regSessionResponse'
-                  examples:
-                    MultipleRegistrations:
-                      summary: Device with multiple active registrations (multi-MSISDN)
-                      value:
-                        - regInfo:
-                            phoneNumber: "+123456789"
-                            regStatus: Registered
-                          registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
-                          expiresAt: "2026-05-05T13:32:17.358Z"
-                        - regInfo:
-                            phoneNumber: "+198765432"
-                            regStatus: Registered
-                          registrationId: "b2c3d4e5-5678-9012-efgh-ab0123456789"
-                          expiresAt: "2026-05-05T14:00:00.000Z"
-                    SingleRegistration:
-                      summary: Device with a single active registration
-                      value:
-                        - regInfo:
-                            phoneNumber: "+123456789"
-                            regStatus: Registered
-                          registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
-                          expiresAt: "2026-05-05T13:32:17.358Z"
-                    NoRegistrations:
-                      summary: No active registrations for the deviceId
-                      value: []
-            '400':
-              $ref: '#/components/responses/Generic400'
-            '401':
-              $ref: '#/components/responses/Generic401'
-            '403':
-              $ref: '#/components/responses/Generic403'
+                type: array
+                maxItems: 10
+                items:
+                  $ref: '#/components/schemas/regSessionResponse'
+              examples:
+                MultipleRegistrations:
+                  summary: Device with multiple active registrations (multi-MSISDN)
+                  value:
+                    - regInfo:
+                        phoneNumber: "+123456789"
+                        regStatus: Registered
+                      registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
+                      expiresAt: "2026-05-05T13:32:17.358Z"
+                    - regInfo:
+                        phoneNumber: "+198765432"
+                        regStatus: Registered
+                      registrationId: "b2c3d4e5-5678-9012-efgh-ab0123456789"
+                      expiresAt: "2026-05-05T14:00:00.000Z"
+                SingleRegistration:
+                  summary: Device with a single active registration
+                  value:
+                    - regInfo:
+                        phoneNumber: "+123456789"
+                        regStatus: Registered
+                      registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
+                      expiresAt: "2026-05-05T13:32:17.358Z"
+                NoRegistrations:
+                  summary: No active registrations for the deviceId
+                  value: []
+        '400':
+          $ref: '#/components/responses/Generic400'
+        '401':
+          $ref: '#/components/responses/Generic401'
+        '403':
+          $ref: '#/components/responses/Generic403'
     post:
       tags:
         - Registration
@@ -249,54 +249,54 @@ paths:
           $ref: "#/components/responses/CreateSessionForbidden403"
   /sessions/{registrationId}:
     get:
-          tags:
-            - Registration
-          summary: Retrieve a device registration
-          description: |-
-            Retrieve an existing registration by its `registrationId`.
+      tags:
+        - Registration
+      summary: Retrieve a device registration
+      description: |-
+        Retrieve an existing registration by its `registrationId`.
 
-            This endpoint allows an API consumer to confirm whether a registration
-            is still active and retrieve its current state. A typical use case is
-            state recovery after a network disconnection or application restart,
-            where the client has a previously stored `registrationId` and needs to
-            verify it is still valid before attempting to create calls or subscribe
-            to events.
+        This endpoint allows an API consumer to confirm whether a registration
+        is still active and retrieve its current state. A typical use case is
+        state recovery after a network disconnection or application restart,
+        where the client has a previously stored `registrationId` and needs to
+        verify it is still valid before attempting to create calls or subscribe
+        to events.
 
-            Returns `404` if the registration does not exist or has expired.
-          operationId: getRegistrationById
-          parameters:
-            - $ref: '#/components/parameters/x-correlator'
-            - $ref: '#/components/parameters/pathParamRegistrationId'
-          security:
-            - openId:
-                - webrtc-registration:sessions:read
-          responses:
-            '200':
-              description: Registration details retrieved successfully
-              headers:
-                x-correlator:
-                  $ref: '#/components/headers/x-correlator'
-              content:
-                application/json:
-                  schema:
-                    $ref: '#/components/schemas/regSessionResponse'
-                  examples:
-                    ActiveRegistration:
-                      summary: Active registration response
-                      value:
-                        regInfo:
-                          phoneNumber: "+123456789"
-                          regStatus: Registered
-                        registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
-                        expiresAt: "2026-05-05T13:32:17.358Z"
-            '400':
-              $ref: '#/components/responses/Generic400'
-            '401':
-              $ref: '#/components/responses/Generic401'
-            '403':
-              $ref: '#/components/responses/Generic403'
-            '404':
-              $ref: '#/components/responses/Generic404'
+        Returns `404` if the registration does not exist or has expired.
+      operationId: getRegistrationById
+      parameters:
+        - $ref: '#/components/parameters/x-correlator'
+        - $ref: '#/components/parameters/pathParamRegistrationId'
+      security:
+        - openId:
+            - webrtc-registration:sessions:read
+      responses:
+        '200':
+          description: Registration details retrieved successfully
+          headers:
+            x-correlator:
+              $ref: '#/components/headers/x-correlator'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/regSessionResponse'
+              examples:
+                ActiveRegistration:
+                  summary: Active registration response
+                  value:
+                    regInfo:
+                      phoneNumber: "+123456789"
+                      regStatus: Registered
+                    registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
+                    expiresAt: "2026-05-05T13:32:17.358Z"
+        '400':
+          $ref: '#/components/responses/Generic400'
+        '401':
+          $ref: '#/components/responses/Generic401'
+        '403':
+          $ref: '#/components/responses/Generic403'
+        '404':
+          $ref: '#/components/responses/Generic404'
     put:
       tags:
         - Registration

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -59,7 +59,9 @@ info:
 
     This API allows to create device registrations. These, identified by a unique
     `registrationId` can be updated and terminated via this API and its methods.
-    - **POST**: Create a new device registration using a valid authorization token.
+    - **GET**: Retrieve an existing device registration via its unique `registrationId`,
+      or retrieve all active registrations for a device via `deviceId` query parameter
+    - **POST**: Create a new device registration using a valid authorization token. Returns `201 Created` on success.
     - **PUT**: Update a device registration via its unique `registrationId`
     - **DELETE**: Finish an existing device registration via its unique `registrationId`
     To receive server-side updates about new voice-video sessions, you need to
@@ -134,6 +136,81 @@ tags:
     description: Operations to manage device registration with the network
 paths:
   /sessions:
+    get:
+          tags:
+            - Registration
+          summary: Retrieve all registrations for a device
+          description: |-
+            Retrieve all active registrations associated with a given `deviceId`.
+
+            This endpoint allows an API consumer to recover registration state
+            after a network disconnection or application restart, where the
+            `registrationId` has been lost but the `deviceId` is known.
+
+            Returns an empty array if no active registrations exist for the
+            given `deviceId`. It is not possible to retrieve registrations
+            belonging to other devices.
+          operationId: getRegistrationsByDeviceId
+          parameters:
+            - $ref: '#/components/parameters/x-correlator'
+            - name: deviceId
+              in: query
+              required: true
+              description: |-
+                The deviceId of the client in UUID format. Only registrations
+                associated with this deviceId will be returned.
+              schema:
+                type: string
+                format: uuid
+          security:
+            - openId:
+                - webrtc-registration:sessions:read
+          responses:
+            '200':
+              description: |-
+                List of active registrations for the given deviceId.
+                Returns an empty array if no active registrations exist.
+              headers:
+                x-correlator:
+                  $ref: '#/components/headers/x-correlator'
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    maxItems: 10
+                    items:
+                      $ref: '#/components/schemas/regSessionResponse'
+                  examples:
+                    MultipleRegistrations:
+                      summary: Device with multiple active registrations (multi-MSISDN)
+                      value:
+                        - regInfo:
+                            phoneNumber: "+123456789"
+                            regStatus: Registered
+                          registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
+                          expiresAt: "2026-05-05T13:32:17.358Z"
+                        - regInfo:
+                            phoneNumber: "+198765432"
+                            regStatus: Registered
+                          registrationId: "b2c3d4e5-5678-9012-efgh-ab0123456789"
+                          expiresAt: "2026-05-05T14:00:00.000Z"
+                    SingleRegistration:
+                      summary: Device with a single active registration
+                      value:
+                        - regInfo:
+                            phoneNumber: "+123456789"
+                            regStatus: Registered
+                          registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
+                          expiresAt: "2026-05-05T13:32:17.358Z"
+                    NoRegistrations:
+                      summary: No active registrations for the deviceId
+                      value: []
+            '400':
+              $ref: '#/components/responses/Generic400'
+            '401':
+              $ref: '#/components/responses/Generic401'
+            '403':
+              $ref: '#/components/responses/Generic403'
     post:
       tags:
         - Registration
@@ -155,8 +232,8 @@ paths:
             schema:
               $ref: '#/components/schemas/regSessionRequest'
       responses:
-        '200':
-          description: Ok
+        '201':
+          description: Created
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
@@ -171,6 +248,55 @@ paths:
         '403':
           $ref: "#/components/responses/CreateSessionForbidden403"
   /sessions/{registrationId}:
+    get:
+          tags:
+            - Registration
+          summary: Retrieve a device registration
+          description: |-
+            Retrieve an existing registration by its `registrationId`.
+
+            This endpoint allows an API consumer to confirm whether a registration
+            is still active and retrieve its current state. A typical use case is
+            state recovery after a network disconnection or application restart,
+            where the client has a previously stored `registrationId` and needs to
+            verify it is still valid before attempting to create calls or subscribe
+            to events.
+
+            Returns `404` if the registration does not exist or has expired.
+          operationId: getRegistrationById
+          parameters:
+            - $ref: '#/components/parameters/x-correlator'
+            - $ref: '#/components/parameters/pathParamRegistrationId'
+          security:
+            - openId:
+                - webrtc-registration:sessions:read
+          responses:
+            '200':
+              description: Registration details retrieved successfully
+              headers:
+                x-correlator:
+                  $ref: '#/components/headers/x-correlator'
+              content:
+                application/json:
+                  schema:
+                    $ref: '#/components/schemas/regSessionResponse'
+                  examples:
+                    ActiveRegistration:
+                      summary: Active registration response
+                      value:
+                        regInfo:
+                          phoneNumber: "+123456789"
+                          regStatus: Registered
+                        registrationId: "a1b2c3d4-1234-5678-abcd-ef0123456789"
+                        expiresAt: "2026-05-05T13:32:17.358Z"
+            '400':
+              $ref: '#/components/responses/Generic400'
+            '401':
+              $ref: '#/components/responses/Generic401'
+            '403':
+              $ref: '#/components/responses/Generic403'
+            '404':
+              $ref: '#/components/responses/Generic404'
     put:
       tags:
         - Registration
@@ -299,7 +425,7 @@ components:
       properties:
         deviceId:
           type: string
-          pattern: uuid
+          format: uuid
           description: |-
             The deviceId of the client in UUID format. A unique identifier for
             the physical device where a registration is initiated. Generated


### PR DESCRIPTION
#### What type of PR is this?
enhancement, fix

#### What this PR does / why we need it:
- Adds GET /sessions?deviceId={deviceId} to retrieve all active registrations
  for a device, supporting multi-MSISDN and state recovery use cases
- Adds GET /sessions/{registrationId} to retrieve a single registration by ID
- Fixes POST /sessions response code from 200 to 201 Created, consistent
  with webrtc-call-handling and webrtc-events APIs
- Fixes deviceId field from pattern: uuid to format: uuid

#### Which issue(s) this PR fixes:
Fixes #149