### PR TITLE
Commonalities v4.2 alignment

### DIFF
--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -61,7 +61,7 @@ info:
     - **SDP**: Acronym for Session Description Protocol. The SDP is a format for
       describing multimedia communication sessions for the purposes of announcement
       and invitation.
-    - **WrtcSDPDescriptor**: Schema to include inside a JSON, a SDP body. You can
+    - **WrtcSdpDescriptor**: Schema to include inside a JSON, a SDP body. You can
       obtain an SDP for WebRTC calling using the WebRTC API provided by the browser
       or any other media library.
 
@@ -519,9 +519,9 @@ components:
         status:
           $ref: '#/components/schemas/SessionStatus'
         offer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         answer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         mediaSessionId:
           type: string
           maxLength: 256
@@ -544,7 +544,7 @@ components:
             guarantee of any particular server-side action or behavior.
           allOf:
             - $ref: '#/components/schemas/LocationDetails'
-    WrtcSDPDescriptor:
+    WrtcSdpDescriptor:
       type: object
       description: |-
         **OFFER**: An inlined session description in SDP format [RFC4566].If XML syntax

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -474,6 +474,7 @@ components:
       explode: false
       schema:
         type: string
+        maxLength: 256
     pathParamMediaSessionId:
       name: mediaSessionId
       in: path
@@ -483,6 +484,7 @@ components:
       explode: false
       schema:
         type: string
+        maxLength: 256
     x-correlator:
       name: x-correlator
       in: header
@@ -494,6 +496,7 @@ components:
       description: Correlator string, UUID format recommended but any string matching the pattern can be used
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
+      maxLength: 256
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
     MediaSessionInformation:
       description: Information about a WebRTC media session including originator and receiver identities, SDP offer/answer, and call status
@@ -503,12 +506,14 @@ components:
           $ref: '#/components/schemas/Address'
         originatorName:
           type: string
+          maxLength: 256
           description: Friendly name of the call originator
           example: 'Alice'
         receiverAddress:
           $ref: '#/components/schemas/Address'
         receiverName:
           type: string
+          maxLength: 256
           description: Friendly name of the call terminator
           example: 'Bob'
         status:
@@ -519,6 +524,7 @@ components:
           $ref: '#/components/schemas/WrtcSDPDescriptor'
         mediaSessionId:
           type: string
+          maxLength: 256
           description: >-
             The media session ID created by the network. The mediaSessionId shall not be
             included in POST requests by the client, but must be included in the notifications
@@ -553,6 +559,7 @@ components:
       properties:
         sdp:
           type: string
+          maxLength: 65536
           description: |-
             An inlined session description in SDP format [RFC4566].If XML syntax is used, the content of this element SHALL be embedded in a CDATA section
     SessionStatus:
@@ -588,14 +595,17 @@ components:
           description: HTTP response status code
         code:
           type: string
+          maxLength: 96
           description: Friendly Code to describe the error
         message:
           type: string
+          maxLength: 512
           description: A human readable description of what the event represent
     Address:
       type: string
       description: Subscriber address (Sender or Receiver)
       pattern: '^(tel:\+[0-9]{5,15}|sip:[A-Za-z0-9_.!%+\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|urn:service:sos(?:\.[a-z0-9](?:[a-z0-9\-]{0,30}[a-z0-9])?)*)$'
+      maxLength: 256
       example: 'tel:+11234567899'
     LocationDetails:
       type: object
@@ -651,6 +661,7 @@ components:
         timestamp:
           type: string
           format: date-time
+          maxLength: 64
           description: The timestamp (in ISO 8601 format) indicating when the location
             information was Calculated. \nThis is crucial for emergency services to
             assess the timeliness of the data. if not provided current timestamp will

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -592,6 +592,7 @@ components:
       properties:
         status:
           type: integer
+          format: int32
           description: HTTP response status code
         code:
           type: string

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -457,6 +457,7 @@ components:
   securitySchemes:
     openId:
       type: openIdConnect
+      description: OpenID Connect authentication via discovery metadata.
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
   headers:
     x-correlator:
@@ -490,10 +491,12 @@ components:
         $ref: "#/components/schemas/XCorrelator"
   schemas:
     XCorrelator:
+      description: Correlator string, UUID format recommended but any string matching the pattern can be used
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
     MediaSessionInformation:
+      description: Information about a WebRTC media session including originator and receiver identities, SDP offer/answer, and call status
       type: object
       properties:
         originatorAddress:
@@ -573,6 +576,7 @@ components:
         - Busy
       example: Ringing
     ErrorInfo:
+      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
       type: object
       required:
         - status
@@ -652,6 +656,7 @@ components:
             assess the timeliness of the data. if not provided current timestamp will
             be used by default"
     CircleCoordinates:
+      description: Geographic coordinates defining a circular area by center point and radius
       type: object
       required:
         - latitude
@@ -671,6 +676,7 @@ components:
           format: float
           description: Radius of the circle in meters, indicating the uncertainty.
     EllipsoidCoordinates:
+      description: Geographic coordinates defining an ellipsoidal uncertainty area in the WGS84 geocentric coordinate system
       type: object
       required:
         - latitude
@@ -708,6 +714,7 @@ components:
   examples:
     exampleRegularMediaSessionRequest:
       summary: Regular call initiation with media information
+      description: Example of a standard outbound call request body with SDP offer
       value:
         originatorAddress: tel:+17085852753
         originatorName: tel:+17085852753
@@ -716,6 +723,7 @@ components:
         offer:
           sdp: "v=0\r\no=- 8066321617929821805 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 42988 RTP/SAVPF 102 113\r\nc=IN IP6 2001:e0:410:2448:7a05:9b11:66f2:c9e\r\nb=AS:64\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=candidate:1645903805 1 udp 2122262783 2001:e0:410:2448:7a05:9b11:66f2:c9e 42988 typ host generation 0 network-id 3 network-cost 900\r\na=ice-ufrag:4eKp\r\na=ice-pwd:D4sF5Pv9vx9ggaqxBlHbAFMx\r\na=ice-options:trickle renomination\r\na=mid:audio\r\n [...]"
     exampleMediaSessionResponse:
+      description: Example response body returned after successfully creating a media session
       value:
         originatorAddress: 'tel:+17085852753'
         originatorName: 'tel:+17085852753'
@@ -726,28 +734,33 @@ components:
         status: Initial
         mediaSessionId: 0AEE1B58BAEEDA3EABA42B32EBB3DFE0DEAD3F90AE0CEB9EEB0C0F703E199FC00E7C6E648F50EE885FF0CE6C7E1CEE795EDD
     exampleSessionStatus183InProgress:
+      description: Session status update indicating the call is in progress (183 Session Progress)
       value:
         receiverSessionStatus:
           status: InProgress
           answer:
             sdp: "v=0\r\no=- 8066321617929821805 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 42988 RTP/SAVPF 102 113\r\nc=IN IP6 2001:e0:410:2448:7a05:9b11:66f2:c9e\r\nb=AS:64\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=candidate:1645903805 1 udp 2122262783 2001:e0:410:2448:7a05:9b11:66f2:c9e 42988 typ host generation 0 network-id 3 network-cost 900\r\na=ice-ufrag:4eKp\r\na=ice-pwd:D4sF5Pv9vx9ggaqxBlHbAFMx\r\na=ice-options:trickle renomination\r\na=mid:audio\r\n [...]"
     exampleSessionStatus180Ringing:
+      description: Session status update indicating the remote end is ringing (180 Ringing)
       value:
         receiverSessionStatus:
           status: Ringing
     exampleSessionStatus200Connected:
+      description: Session status update indicating the call has been answered and connected (200 OK)
       value:
         receiverSessionStatus:
           status: Connected
           answer:
             sdp: "v=0\r\no=- 4576312012535546667 4 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 47510 RTP/SAVPF 102 113\r\nc=IN IP6 2001:e0:410:243a:a344:cee7:7b39:bb1e\r\nb=AS:64\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=candidate:3108871805 1 udp 2122262783 2001:e0:410:243a:a344:cee7:7b39:bb1e 47510 typ host generation 0 network-id 3 network-cost 900\r\na=ice-ufrag:47Nx\r\na=ice-pwd:ln3CttOSkObcQ7A0tYO1LXqy\r\na=ice-options:trickle renomination\r\na=mid:audio\r\n [...]"
     exampleSessionStatusHold:
+      description: Session status update indicating the call has been placed on hold
       value:
         ReceiverSessionStatus:
           status: Hold
           answer:
             sdp: "v=0\r\no=- 4576312012535546667 4 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 47510 RTP/SAVPF 102 113\r\nc=IN IP6 2001:e0:410:243a:a344:cee7:7b39:bb1e\r\nb=AS:64\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=candidate:3108871805 1 udp 2122262783 2001:e0:410:243a:a344:cee7:7b39:bb1e 47510 typ host generation 0 network-id 3 network-cost 900\r\na=ice-ufrag:47Nx\r\na=ice-pwd:ln3CttOSkObcQ7A0tYO1LXqy\r\na=ice-options:trickle renomination\r\na=mid:audio\r\n [...]"
     exampleSessionStatusResume:
+      description: Session status update indicating a held call has been resumed
       value:
         ReceiverSessionStatus:
           status: Resume
@@ -755,6 +768,7 @@ components:
             sdp: "v=0\r\no=- 4576312012535546667 4 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 47510 RTP/SAVPF 102 113\r\nc=IN IP6 2001:e0:410:243a:a344:cee7:7b39:bb1e\r\nb=AS:64\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=candidate:3108871805 1 udp 2122262783 2001:e0:410:243a:a344:cee7:7b39:bb1e 47510 typ host generation 0 network-id 3 network-cost 900\r\na=ice-ufrag:47Nx\r\na=ice-pwd:ln3CttOSkObcQ7A0tYO1LXqy\r\na=ice-options:trickle renomination\r\na=mid:audio\r\n [...]"
     exampleSessionStatusConnectedWithLocation:
       summary: Answering party accepts the call and shares their device location
+      description: Session status update for a connected call where the answering party shares device location
       value:
         status: Connected
         answer:
@@ -772,6 +786,7 @@ components:
           timestamp: '2025-10-06T19:32:10Z'
     exampleSessionStatusLocationUpdate:
       summary: Post-setup location update by either party
+      description: Session status update carrying a location update from either call party after the session is established
       value:
         status: Connected
         locationDetails:
@@ -787,6 +802,7 @@ components:
           timestamp: '2025-10-06T19:45:00Z'
     exampleEmergencyMediaSessionRequest:
       summary: Emergency call initiation with location details
+      description: Example request body for initiating an emergency call with caller location details
       value:
         originatorAddress: 'tel:+17085852753'
         originatorName: Alice
@@ -809,6 +825,7 @@ components:
           timestamp: '2025-10-06T19:31:25Z'
     exampleLocatedMediaSessionRequest:
       summary: Regular call initiation with location details
+      description: Example request body for a regular call that includes caller location details
       value:
         originatorAddress: 'tel:+17085852753'
         originatorName: Alice

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -593,6 +593,8 @@ components:
         status:
           type: integer
           format: int32
+          minimum: 100
+          maximum: 599
           description: HTTP response status code
         code:
           type: string

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -538,6 +538,7 @@ components:
       description: Correlator string, UUID format recommended but any string matching the pattern can be used
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
+      maxLength: 256
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
     ErrorInfo:
@@ -553,9 +554,11 @@ components:
           description: HTTP response status code
         code:
           type: string
+          maxLength: 96
           description: A human-readable code to describe the error
         message:
           type: string
+          maxLength: 512
           description: A human-readable description of what the event represents
 
     SubscriptionRequest:
@@ -573,6 +576,7 @@ components:
           type: string
           format: uri
           pattern: ^https:\/\/.+$
+          maxLength: 1024
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
@@ -627,6 +631,7 @@ components:
         subscriptionExpireTime:
           type: string
           format: date-time
+          maxLength: 64
           example: 2023-01-17T13:18:23.682Z
           description: |-
             The subscription expiration time (in date-time format) requested by the API consumer.
@@ -654,6 +659,7 @@ components:
         subscriptionExpireTime:
           type: string
           format: date-time
+          maxLength: 64
           example: "2023-01-17T13:18:23.682Z"
           description: |-
             The updated subscription expiration time requested by the API consumer.
@@ -694,9 +700,11 @@ components:
             accessToken:
               description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
               type: string
+              maxLength: 8192
             accessTokenExpiresUtc:
               type: string
               format: date-time
+              maxLength: 64
               description: |
                 REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
                 In the case of an ACCESS_TOKEN_EXPIRED termination reason, implementation should notify the client before the expiration date.
@@ -727,6 +735,7 @@ components:
         deviceId:
           type: string
           format: uuid
+          maxLength: 36
           description: |-
             The device-id of the client in UUID format. A unique identifier for
             the physical device where a registration is initiated. Generated
@@ -765,6 +774,7 @@ components:
           type: string
           format: uri
           pattern: ^https:\/\/.+$
+          maxLength: 1024
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         types:
@@ -782,6 +792,7 @@ components:
         startsAt:
           type: string
           format: date-time
+          maxLength: 64
           description: |
             Date when the event subscription will begin/began
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
@@ -789,6 +800,7 @@ components:
         expiresAt:
           type: string
           format: date-time
+          maxLength: 64
           description: |
             Date when the event subscription will expire. Only provided when `subscriptionExpireTime` is indicated by API client or Telco Operator has specific policy about that.
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
@@ -818,11 +830,13 @@ components:
 
     SubscriptionId:
       type: string
+      maxLength: 256
       description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, this concept SHALL be referred as `subscriptionId` as per [Commonalities Event Notification Model](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#122-event-notification).
       example: qs15-h556-rt89-1298
 
     RegistrationId:
       type: string
+      maxLength: 256
       description: The unique identifier of the WebRTC registration.
       example: ln3C-ttOSk-ObcQ7A0-tYO1LXqy
 
@@ -838,11 +852,13 @@ components:
       properties:
         id:
           type: string
+          maxLength: 256
           description: identifier of this event, that must be unique in the source context.
         source:
           $ref: "#/components/schemas/Source"
         type:
           type: string
+          maxLength: 512
           description: |-
             event-type that describes type of notification
         specversion:
@@ -875,6 +891,7 @@ components:
       type: string
       format: uri-reference
       minLength: 1
+      maxLength: 2048
       description: |-
         Identifies the context in which an event happened - be a non-empty `URI-reference` like:
         - URI with a DNS authority:
@@ -890,6 +907,7 @@ components:
     DateTime:
       type: string
       format: date-time
+      maxLength: 64
       description: |-
         Timestamp of when the occurrence happened.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
@@ -954,18 +972,22 @@ components:
           type: string
           description: Sender (originator) address
           pattern: '^(tel:\+[0-9]{5,15}|sip:[A-Za-z0-9_.!%+\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})$'
+          maxLength: 256
           example: 'tel:+11234567899'
         originatorName:
           type: string
+          maxLength: 256
           description: Friendly name of the call originator
           example: 'Alice'
         receiverAddress:
           type: string
           description: Receiver (terminator) address
           pattern: '^(tel:\+[0-9]{5,15}|sip:[A-Za-z0-9_.!%+\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})$'
+          maxLength: 256
           example: 'tel:+11234567899'
         receiverName:
           type: string
+          maxLength: 256
           description: Friendly name of the call terminator
           example: 'Bob'
         status:
@@ -996,10 +1018,12 @@ components:
           $ref: '#/components/schemas/WrtcSDPDescriptor'
         mediaSessionId:
           type: string
+          maxLength: 256
           description: The media session ID created by the network. The mediaSessionId shall not be included in POST requests by the client, but must be included in the notifications from the network to client.
           example: '0AEE1B58BAEEDA3EABA42B32EBB3DFE07E9CFF402EAF9EED8EF'
         reason:
           type: string
+          maxLength: 2048
           description: The description of the event that has happened within the session
         sequenceNumber:
           type: integer
@@ -1035,6 +1059,7 @@ components:
       properties:
         sdp:
           type: string
+          maxLength: 65536
           description: |-
             An inlined session description in SDP format [RFC4566].If XML syntax is used, the content of this element SHALL be embedded in a CDATA section
 
@@ -1064,6 +1089,7 @@ components:
           $ref: "#/components/schemas/TerminationReason"
         terminationDescription:
           type: string
+          maxLength: 2048
           description: Human-readable explanation of why the subscription was terminated
 
     TerminationReason:
@@ -1107,6 +1133,7 @@ components:
           $ref: "#/components/schemas/RegistrationId"
         terminationDescription:
           type: string
+          maxLength: 2048
           description: Human-readable explanation of why the registration was terminated
         terminationReason:
           $ref: "#/components/schemas/RegistrationTerminationReason"
@@ -1150,6 +1177,7 @@ components:
             NOTE: Use/Applicability of this concept has not been discussed in Commonalities under the scope of Meta Release v0.4. When required by an API project as an option to meet a UC/Requirement, please generate an issue for Commonalities discussion about it.
           additionalProperties:
             type: string
+            maxLength: 512
         method:
           type: string
           description: The HTTP method to use for sending the message.
@@ -1209,6 +1237,7 @@ components:
         timestamp:
           type: string
           format: date-time
+          maxLength: 64
           description: The timestamp (in ISO 8601 format) indicating when the location
             information was Calculated. \nThis is crucial for emergency services to
             assess the timeliness of the data. if not provided current timestamp will

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -1013,9 +1013,9 @@ components:
             - NotReachable
             - Busy
         offer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         answer:
-          $ref: '#/components/schemas/WrtcSDPDescriptor'
+          $ref: '#/components/schemas/WrtcSdpDescriptor'
         mediaSessionId:
           type: string
           maxLength: 256
@@ -1053,7 +1053,7 @@ components:
             - receiverAddress
             - status
 
-    WrtcSDPDescriptor:
+    WrtcSdpDescriptor:
       description: SDP descriptor object carrying an inlined Session Description Protocol payload
       type: object
       properties:

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -366,6 +366,7 @@ paths:
               schema:
                 type: array
                 minItems: 0
+                maxItems: 100
                 items:
                   $ref: '#/components/schemas/Subscription'
         "400":

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -552,6 +552,8 @@ components:
         status:
           type: integer
           format: int32
+          minimum: 100
+          maximum: 599
           description: HTTP response status code
         code:
           type: string
@@ -642,6 +644,7 @@ components:
           format: int32
           description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends. Up to API project decision to keep it.
           minimum: 1
+          maximum: 1000000
           example: 5
         initialEvent:
           type: boolean
@@ -1030,6 +1033,8 @@ components:
         sequenceNumber:
           type: integer
           format: int32
+          minimum: 1
+          maximum: 2147483647
           description: The sequence number of the notification sent to client
         locationDetails:
           description: Location of the party that generated this event.

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -714,6 +714,7 @@ components:
           `deviceId` related to a valid registration.
         - org.camaraproject.webrtc-events.v0.session-status requires a
           `deviceId` related to a valid registration.
+      type: object
       required:
         - deviceId
       properties:
@@ -821,6 +822,7 @@ components:
 
     CloudEvent:
       description: The notification callback
+      type: object
       required:
         - id
         - source

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -505,11 +505,15 @@ components:
   securitySchemes:
     openId:
       type: openIdConnect
+      description: OpenID Connect authentication via discovery metadata.
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
     notificationsBearerAuth:
       type: http
       scheme: bearer
       bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      description: |-
+        Bearer token for notification delivery. Token format is determined
+        by `sinkCredential.credentialType` in the subscription request.
   parameters:
     SubscriptionId:
       name: subscriptionId
@@ -531,11 +535,13 @@ components:
         $ref: "#/components/schemas/XCorrelator"
   schemas:
     XCorrelator:
+      description: Correlator string, UUID format recommended but any string matching the pattern can be used
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
     ErrorInfo:
+      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
       type: object
       required:
         - status
@@ -1004,6 +1010,7 @@ components:
             - $ref: '#/components/schemas/LocationDetails'
 
     MediaSessionStatusUpdate:
+      description: MediaSession information emitted on a session-status event
       allOf:
         - $ref: "#/components/schemas/MediaSession"
         - type: object
@@ -1012,6 +1019,7 @@ components:
             - status
 
     MediaSessionInvite:
+      description: MediaSession information emitted on a session-invitation event
       allOf:
         - $ref: "#/components/schemas/MediaSession"
         - type: object
@@ -1022,6 +1030,7 @@ components:
             - status
 
     WrtcSDPDescriptor:
+      description: SDP descriptor object carrying an inlined Session Description Protocol payload
       type: object
       properties:
         sdp:
@@ -1055,6 +1064,7 @@ components:
           $ref: "#/components/schemas/TerminationReason"
         terminationDescription:
           type: string
+          description: Human-readable explanation of why the subscription was terminated
 
     TerminationReason:
       type: string
@@ -1097,6 +1107,7 @@ components:
           $ref: "#/components/schemas/RegistrationId"
         terminationDescription:
           type: string
+          description: Human-readable explanation of why the registration was terminated
         terminationReason:
           $ref: "#/components/schemas/RegistrationTerminationReason"
 
@@ -1110,6 +1121,7 @@ components:
         - REGISTRATION_EXPIRED
 
     HTTPSubscriptionRequest:
+      description: Subscription request for HTTP-based event delivery.
       allOf:
         - $ref: "#/components/schemas/SubscriptionRequest"
         - type: object
@@ -1118,6 +1130,7 @@ components:
               $ref: "#/components/schemas/HTTPSettings"
 
     HTTPSubscriptionResponse:
+      description: Subscription resource returned for HTTP-based event delivery.
       allOf:
         - $ref: "#/components/schemas/Subscription"
         - type: object
@@ -1126,6 +1139,7 @@ components:
               $ref: "#/components/schemas/HTTPSettings"
 
     HTTPSettings:
+      description: HTTP protocol settings for event delivery.
       type: object
       properties:
         headers:
@@ -1200,6 +1214,7 @@ components:
             assess the timeliness of the data. if not provided current timestamp will
             be used by default"
     CircleCoordinates:
+      description: Geographic coordinates defining a circular area by center point and radius
       type: object
       required:
         - latitude
@@ -1219,6 +1234,7 @@ components:
           format: float
           description: Radius of the circle in meters, indicating the uncertainty.
     EllipsoidCoordinates:
+      description: Geographic coordinates defining an ellipsoidal uncertainty area in the WGS84 geocentric coordinate system
       type: object
       required:
         - latitude

--- a/code/API_definitions/webrtc-events.yaml
+++ b/code/API_definitions/webrtc-events.yaml
@@ -551,6 +551,7 @@ components:
       properties:
         status:
           type: integer
+          format: int32
           description: HTTP response status code
         code:
           type: string
@@ -638,6 +639,7 @@ components:
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
         subscriptionMaxEvents:
           type: integer
+          format: int32
           description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends. Up to API project decision to keep it.
           minimum: 1
           example: 5
@@ -1027,6 +1029,7 @@ components:
           description: The description of the event that has happened within the session
         sequenceNumber:
           type: integer
+          format: int32
           description: The sequence number of the notification sent to client
         locationDetails:
           description: Location of the party that generated this event.

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -542,6 +542,8 @@ components:
         status:
           type: integer
           format: int32
+          minimum: 100
+          maximum: 599
           description: HTTP response status code
         code:
           type: string

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -541,6 +541,7 @@ components:
       properties:
         status:
           type: integer
+          format: int32
           description: HTTP response status code
         code:
           type: string

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -180,7 +180,7 @@ paths:
                 type: array
                 maxItems: 10
                 items:
-                  $ref: '#/components/schemas/regSessionResponse'
+                  $ref: '#/components/schemas/RegSessionResponse'
               examples:
                 MultipleRegistrations:
                   summary: Device with multiple active registrations (multi-MSISDN)
@@ -231,7 +231,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/regSessionRequest'
+              $ref: '#/components/schemas/RegSessionRequest'
       responses:
         '201':
           description: Created
@@ -241,7 +241,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/regSessionResponse'
+                $ref: '#/components/schemas/RegSessionResponse'
         '400':
           $ref: "#/components/responses/CreateSessionBadRequest400"
         '401':
@@ -280,7 +280,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/regSessionResponse'
+                $ref: '#/components/schemas/RegSessionResponse'
               examples:
                 ActiveRegistration:
                   summary: Active registration response
@@ -333,7 +333,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/regSessionUpdate'
+              $ref: '#/components/schemas/RegSessionUpdate'
       responses:
         '200':
           description: Ok
@@ -343,7 +343,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/regSessionResponse'
+                $ref: '#/components/schemas/RegSessionResponse'
         '204':
           description: Updated the registration status (no content)
           headers:
@@ -423,7 +423,7 @@ components:
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
       maxLength: 256
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-    regSessionRequest:
+    RegSessionRequest:
       description: Request body for creating a new WebRTC device registration
       type: object
       required:
@@ -467,7 +467,7 @@ components:
               according to its own TTL policy and return the authoritative expiry in
               `expiresAt` in the response.
 
-    regSessionResponse:
+    RegSessionResponse:
       description: Response body returned after successfully creating or refreshing a WebRTC device registration
       type: object
       required:
@@ -492,7 +492,7 @@ components:
             and plan to refresh well in advance to avoid race conditions. A suggested margin is 120 seconds before expiry.
 
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-    regSessionUpdate:
+    RegSessionUpdate:
       description: Request body for refreshing an existing WebRTC device registration
       type: object
       properties:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -162,6 +162,7 @@ paths:
           schema:
             type: string
             format: uuid
+            maxLength: 36
       security:
         - openId:
             - webrtc-registration:sessions:read
@@ -414,11 +415,13 @@ components:
       explode: false
       schema:
         type: string
+        maxLength: 256
   schemas:
     XCorrelator:
       description: Correlator string, UUID format recommended but any string matching the pattern can be used
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
+      maxLength: 256
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
     regSessionRequest:
       description: Request body for creating a new WebRTC device registration
@@ -429,6 +432,7 @@ components:
         deviceId:
           type: string
           format: uuid
+          maxLength: 36
           description: |-
             The deviceId of the client in UUID format. A unique identifier for
             the physical device where a registration is initiated. Generated
@@ -436,6 +440,7 @@ components:
         registrationExpireTime:
           type: string
           format: date-time
+          maxLength: 64
           description: |-
             Optional **absolute** expiry moment for this registration.
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must include a time offset.
@@ -472,10 +477,12 @@ components:
           $ref: '#/components/schemas/RegistrationInformation'
         registrationId:
           type: string
+          maxLength: 256
           description: The registration session ID is returned when registering a device with the network . Clients must utilize this ID to as a parameter in the call-handling and subscription APIs.
         expiresAt:
           type: string
           format: date-time
+          maxLength: 64
           description: |-
             Authoritative expiry timestamp calculated **after** applying the
             refresh logic. Clients MUST treat this value as the new upper-bound
@@ -492,6 +499,7 @@ components:
         registrationExpireTime:
           type: string
           format: date-time
+          maxLength: 64
           description: |-
             Optional **absolute** UTC timestamp that *requests* a new expiry.
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must include a time offset.
@@ -536,14 +544,17 @@ components:
           description: HTTP response status code
         code:
           type: string
+          maxLength: 96
           description: Friendly Code to describe the error
         message:
           type: string
+          maxLength: 512
           description: A human readable description of what the event represent
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       type: string
       pattern: '^\+[1-9][0-9]{4,14}$'
+      maxLength: 128
       example: "+123456789"
 
   responses:

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -391,6 +391,7 @@ components:
   securitySchemes:
     openId:
       type: openIdConnect
+      description: OpenID Connect authentication via discovery metadata.
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
   headers:
     x-correlator:
@@ -415,10 +416,12 @@ components:
         type: string
   schemas:
     XCorrelator:
+      description: Correlator string, UUID format recommended but any string matching the pattern can be used
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
     regSessionRequest:
+      description: Request body for creating a new WebRTC device registration
       type: object
       required:
         - deviceId
@@ -460,6 +463,7 @@ components:
               `expiresAt` in the response.
 
     regSessionResponse:
+      description: Response body returned after successfully creating or refreshing a WebRTC device registration
       type: object
       required:
         - registrationId
@@ -482,6 +486,7 @@ components:
 
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
     regSessionUpdate:
+      description: Request body for refreshing an existing WebRTC device registration
       type: object
       properties:
         registrationExpireTime:
@@ -506,10 +511,12 @@ components:
 
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
     RegistrationStatus:
+      description: Current registration status of the WebRTC device
       type: string
       enum:
         - Registered
     RegistrationInformation:
+      description: Information about the registered device including phone number and registration status
       type: object
       properties:
         phoneNumber:
@@ -517,6 +524,7 @@ components:
         regStatus:
           $ref: '#/components/schemas/RegistrationStatus'
     ErrorInfo:
+      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
       type: object
       required:
         - status


### PR DESCRIPTION
### What type of PR is this?

* correction

### What this PR does / why we need it:

* Commonalities release v4.2 aligment for Sync26 release

### Which issue(s) this PR fixes:

Fixes #173 
Fixes #114 

### Special notes for reviewers:

There are a lot of additions, but all of them are formal limits, mostly taken from Commonalities

_**One error that we needed to fix**_
- [S-016] All schemas must declare a type, so a generic "object" is added when not declared

_**Warnings (simple changes)**_
- [S-011] All schemas must include a description --> LLM work
- [S-312] Max length is required for strings. Some are based on commonalites, for the rest, here is my approach:
  - sink URLs: 1024
  - JWT auth: 8192
  - phoneNumber: 128
  - uuids: 36 (classic pattern 6e8bc430-9c3a-11d9-9669-0800200c9a66)
  - other WebRTC ids with pattern defined (ex.: mediaSessionId): 256
- [S-015] PascalCase fix --> Third attempt 😅 
- [S-310] Integer type required --> assumed int32
- [S-311] Integer max/min required --> commonalities defined  
- [S-309] Array maxItems --> commonalities defined 

#### Changelog input

```
 release-note
- fix(events): Commonalites v4.2 aligment
- fix(registration): Commonalites v4.2 aligment
- fix(call-handling): Commonalites v4.2 aligment 
```

#### Additional documentation 

n/a