### PR TITLE
enhance: Address schema in webrtc-call-handling

### DIFF
--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -650,8 +650,8 @@ components:
 
         The reserved value `sip:anonymous@anonymous.invalid` (as defined in RFC 3323) MAY be used to indicate
         that the calling party identity is withheld within the trust domain. When `sip:anonymous@anonymous.invalid` is set
-        as the `originatorAddress`, the session SHALL be handled as an anonymous call origination, and the originator's identity
-        SHALL NOT be presented to the receiver. This value SHALL NOT be used as the `receiverAddress`.
+        as the `originatorAddress`, the session SHALL be handled as an anonymous call origination.
+        This value SHALL NOT be used as the `receiverAddress`.
 
       pattern: '^(tel:\+[1-9][0-9]{4,14}|tel:[0-9*#]{1,15};phone-context=(?:\+[1-9][0-9]{0,14}|[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)+)|sip:[A-Za-z0-9_.!%+\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|sip:[0-9*#]{1,15};phone-context=(?:\+[1-9][0-9]{0,14}|[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)+)@[A-Za-z0-9.-]+\.[A-Za-z]{2,};user=phone|urn:service:sos(?:\.[a-z0-9](?:[a-z0-9\-]{0,30}[a-z0-9])?)*|sip:anonymous@anonymous\.invalid)$'
       example: 'tel:+11234567899'

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -634,8 +634,27 @@ components:
           description: A human readable description of what the event represent
     Address:
       type: string
-      description: Subscriber address (Sender or Receiver)
-      pattern: '^(tel:\+[0-9]{5,15}|sip:[A-Za-z0-9_.!%+\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|urn:service:sos(?:\.[a-z0-9](?:[a-z0-9\-]{0,30}[a-z0-9])?)*)$'
+      description: >-
+        Subscriber address (Sender or Receiver).
+        The following formats are supported:
+        - A TEL URI :
+          - an international format; or
+          - a home local number (as defined in 3GPP TS 24.229 subclause 5.1.2A.1.5) qualified by a `phone-context` 
+            parameter identifying the home network numbering plan.
+        - A SIP URI :
+          - standard SIP URI;
+          - The user part MAY contain a home local number qualified by a `phone-context` parameter, in which case 
+            the `user=phone` URI parameter SHALL be appended;
+          - an emergency service URN; or
+          - anonymous SIP URI
+          
+        The reserved value `sip:anonymous@anonymous.invalid` (as defined in RFC 3323) MAY be used to indicate 
+        that the calling party identity is withheld within the trust domain. When `sip:anonymous@anonymous.invalid` is set
+        as the `originatorAddress`, the session SHALL be handled as an anonymous call origination, and the originator's identity
+        SHALL NOT be presented to the receiver. This value SHALL NOT be used as the `receiverAddress`.
+
+      pattern: '^(tel:\+[1-9][0-9]{4,14}|tel:[0-9*#]{1,15};phone-context=(?:\+[1-9][0-9]{0,14}|[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)+)|sip:[A-Za-z0-9_.!%+\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|sip:[0-9*#]{1,15};phone-context=(?:\+[1-9][0-9]{0,14}|[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)+)@[A-Za-z0-9.-]+\.[A-Za-z]{2,};user=phone|urn:service:sos(?:\.[a-z0-9](?:[a-z0-9\-]{0,30}[a-z0-9])?)*|sip:anonymous@anonymous\.invalid)$'
+      example: 'tel:+11234567899'
       maxLength: 256
       example: 'tel:+11234567899'
     LocationDetails:

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -642,9 +642,9 @@ components:
           - a home local number (as defined in 3GPP TS 24.229 subclause 5.1.2A.1.5) qualified by a `phone-context`
             parameter identifying the home network numbering plan.
         - A SIP URI :
-          - standard SIP URI;
-          - The user part MAY contain a home local number qualified by a `phone-context` parameter, in which case
-            the `user=phone` URI parameter SHALL be appended;
+          - SIP URI with a generic user part;
+          - SIP URI with a home local number (`user=phone`). The user part MAY contain a home local number qualified by
+            a `phone-context` parameter, in which case the `user=phone` URI parameter SHALL be appended;
           - an emergency service URN; or
           - anonymous SIP URI
 

--- a/code/API_definitions/webrtc-call-handling.yaml
+++ b/code/API_definitions/webrtc-call-handling.yaml
@@ -639,16 +639,16 @@ components:
         The following formats are supported:
         - A TEL URI :
           - an international format; or
-          - a home local number (as defined in 3GPP TS 24.229 subclause 5.1.2A.1.5) qualified by a `phone-context` 
+          - a home local number (as defined in 3GPP TS 24.229 subclause 5.1.2A.1.5) qualified by a `phone-context`
             parameter identifying the home network numbering plan.
         - A SIP URI :
           - standard SIP URI;
-          - The user part MAY contain a home local number qualified by a `phone-context` parameter, in which case 
+          - The user part MAY contain a home local number qualified by a `phone-context` parameter, in which case
             the `user=phone` URI parameter SHALL be appended;
           - an emergency service URN; or
           - anonymous SIP URI
-          
-        The reserved value `sip:anonymous@anonymous.invalid` (as defined in RFC 3323) MAY be used to indicate 
+
+        The reserved value `sip:anonymous@anonymous.invalid` (as defined in RFC 3323) MAY be used to indicate
         that the calling party identity is withheld within the trust domain. When `sip:anonymous@anonymous.invalid` is set
         as the `originatorAddress`, the session SHALL be handled as an anonymous call origination, and the originator's identity
         SHALL NOT be presented to the receiver. This value SHALL NOT be used as the `receiverAddress`.
@@ -656,7 +656,6 @@ components:
       pattern: '^(tel:\+[1-9][0-9]{4,14}|tel:[0-9*#]{1,15};phone-context=(?:\+[1-9][0-9]{0,14}|[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)+)|sip:[A-Za-z0-9_.!%+\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|sip:[0-9*#]{1,15};phone-context=(?:\+[1-9][0-9]{0,14}|[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)+)@[A-Za-z0-9.-]+\.[A-Za-z]{2,};user=phone|urn:service:sos(?:\.[a-z0-9](?:[a-z0-9\-]{0,30}[a-z0-9])?)*|sip:anonymous@anonymous\.invalid)$'
       example: 'tel:+11234567899'
       maxLength: 256
-      example: 'tel:+11234567899'
     LocationDetails:
       type: object
       description: >-


### PR DESCRIPTION
Expanded the description for Subscriber address to include supported formats and usage of anonymous SIP URI.

#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:
This PR extends the Address schema to support anonymous call origination.

Main change — anonymous call origination:
The reserved value sip:anonymous@anonymous.invalid, as defined in RFC 3323, is added to the Address schema. When this value is set as the originatorAddress, the session is handled as an anonymous call origination and the originator's identity is not presented to the receiver. The value is restricted to originatorAddress and must not be used as receiverAddress.

Supplementary change — home local numbers in the pattern:
While updating the pattern, support for home local numbers (3GPP TS 24.229 subclause 5.1.2A.1.5) has been added, in both tel URI form and SIP URI form.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #177

#### Special notes for reviewers:

The following formats are supported:

- A TEL URI :

    - an international format; or
    - a home local number (as defined in 3GPP TS 24.229 subclause 5.1.2A.1.5) qualified by a `phone-context` parameter identifying the home network numbering plan.

- A SIP URI 
   - SIP URI with a generic user part;
   - SIP URI with a home local number (`user=phone`). The user part MAY contain a home local number qualified by a `phone-context` parameter, in which case the `user=phone` URI parameter SHALL be appended;
   - an emergency service URN; or
   - anonymous SIP URI  
      - The reserved value `sip:anonymous@anonymous.invalid` (as defined in RFC 3323) MAY be used to indicate that the calling party identity is withheld within the trust domain. When `sip:anonymous@anonymous.invalid` is set as the `originatorAddress`, the session SHALL be handled as an anonymous call origination. This value SHALL NOT be used as the `receiverAddress`.

#### Changelog input

```
 release-note - webrtc-call-handling
- Added reserved value sip:anonymous@anonymous.invalid (RFC 3323) to Address schema to support anonymous call origination
- Extended Address pattern to support home local numbers (3GPP TS 24.229) in tel URI and SIP URI formats
```