### PR TITLE
Enhance WebRTC registration API documentation

### DIFF
--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -37,10 +37,14 @@ info:
       Retrieved using the `webrtc-registration` API
     - **deviceId**: A unique identifier for the physical device where a media
       session is initiated. It is provided by the WebRTC application, it remains
-      consistent across multiple installations or logins on the same device. Its
-      primary function is to ensure that only one WebRTC session (**registration**)
-      is active per device at a time, enabling the gateway to clean up any stale
-      sessions if a new session is initiated on the same device.
+      consistent across multiple installations or logins on the same device. An
+      active registration is uniquely identified by the combination of
+      `deviceId` and the `phoneNumber` resolved from the API consumer's access
+      token; an attempt to create a second active registration for the same
+      (`deviceId`, `phoneNumber`) combination is rejected with `409 ALREADY_EXISTS`.
+      The same `deviceId` MAY have multiple active registrations concurrently
+      when authorized by access tokens bound to different phone numbers (e.g.
+      multi-line / multi-MSISDN devices).
     - **media session**: An exchange of media between devices.
       Typical example of session is a "single one-to-one call".
     - **mediaSessionId**: Unique identifier of a Voice or Video **session** using
@@ -217,10 +221,40 @@ paths:
         - Registration
       summary: Create a registration
       description: |-
-        API endpoint used to create a new registration of a device in the network.
-        It uses the `deviceId` in the request body.
-        In response, a `registrationId` (in UUID format) is provided to identify
-        this device registration within the network.
+        Create a new device registration in the network using a client-supplied
+        `deviceId`. The subscriber identifier (`phoneNumber`) for the
+        registration is derived from the API consumer's access token, not from
+        the request body. On success, the server returns a server-allocated
+        `registrationId` (UUID) that the client uses for all subsequent
+        operations on this registration.
+
+        **Uniqueness constraint:**
+
+        An active registration is uniquely identified by the combination of the
+        client-supplied `deviceId` and the `phoneNumber` resolved from the
+        access token. Only one active registration is allowed per
+        (`deviceId`, `phoneNumber`) combination at any time.
+
+        - If the API consumer issues a POST whose (`deviceId`, `phoneNumber`)
+          matches an existing active registration, the server **does not**
+          modify or replace it. The request is rejected with `409 ALREADY_EXISTS`.
+        - The same `deviceId` MAY be used to create additional registrations
+          concurrently, provided each request is authorized by an access token
+          bound to a different `phoneNumber` (e.g. multi-line / multi-MSISDN
+          devices). Per-user and per-MSISDN limits still apply and are
+          enforced via `403` responses.
+
+        To recover from a `409`, the API consumer SHOULD:
+          1. Call `GET /sessions?deviceId={deviceId}` to enumerate active
+             registrations for the device and locate the entry whose
+             `phoneNumber` matches the current access token, and either
+          2. Continue using the existing `registrationId` as-is, or
+          3. Call `DELETE /sessions/{registrationId}` to terminate it before
+             issuing a new POST.
+
+        Updates to attributes of an existing registration (e.g. extending the
+        expiry) MUST be performed via `PUT /sessions/{registrationId}`, not by
+        re-POSTing.
       operationId: createRegistration
       parameters:
         - $ref: '#/components/parameters/x-correlator'
@@ -248,6 +282,8 @@ paths:
           $ref: "#/components/responses/Generic401"
         '403':
           $ref: "#/components/responses/CreateSessionForbidden403"
+        '409':
+          $ref: "#/components/responses/CreateSessionConflict409"
   /sessions/{registrationId}:
     get:
       tags:
@@ -654,6 +690,36 @@ components:
                 status: 403
                 code: MAX_DEVICES_PER_USER
                 message: 'The maximum number of device instances per user has been reached'
+    CreateSessionConflict409:
+      description: Conflict
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - ALREADY_EXISTS
+          examples:
+            CREATE_409_ALREADY_EXISTS:
+              description: |-
+                An active registration already exists for the combination of
+                the supplied `deviceId` and the `phoneNumber` resolved from
+                the access token. The client should retrieve the existing
+                registration via `GET /sessions?deviceId={deviceId}` and
+                either reuse it or terminate it with DELETE before retrying.
+              value:
+                status: 409
+                code: ALREADY_EXISTS
+                message: An active registration already exists for the supplied deviceId and the phoneNumber resolved from the access token.
     # Generic responses
     Generic400:
       description: Bad Request


### PR DESCRIPTION
Updated the WebRTC registration API documentation to clarify uniqueness constraints and registration process.

#### What type of PR is this?

Add one of the following kinds:
* cleanup


#### What this PR does / why we need it:
This PR clarifies the intended behavior of the `POST /sessions` operation to remove ambiguity around registration creation.

- Clarify that an active registration is uniquely identified by the combination of `deviceId` and the `phoneNumber` resolved from the access token.
- Clarify that `POST` is only used to create a new registration.
- Specify that a `POST` request for an existing active registration (`deviceId`, `phoneNumber`) is rejected with `409 ALREADY_EXISTS`.
- Clarify that updates to an existing registration (e.g. extending its expiry) MUST be performed via `PUT /sessions/{registrationId}`.
- Add recovery guidance for API consumers after receiving `409 ALREADY_EXISTS`.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #145 

#### Changelog input

```
 release-note - webrtc-registration
- Clarification on the POST /sessions operation

```
