### PR TITLE
task: temporary remove of webrtc-events from release to renaming

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -40,14 +40,6 @@ apis:
       - pradeepachar-mavenir
       - deepakjaiswal1
       - teikuran
-  - api_name: webrtc-events
-    target_api_version: 0.3.0
-    target_api_status: rc
-    main_contacts:
-      - stroncoso
-      - pradeepachar-mavenir
-      - deepakjaiswal1
-      - teikuran
   - api_name: webrtc-registration
     target_api_version: 0.4.0
     target_api_status: rc


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

Renaming of the webrtc-events API requires an intermediate step: remove, then add again with the new name.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for reviewers:

More info at https://github.com/camaraproject/WebRTC/pull/183

#### Changelog input

```
 release-note
task: update webrtc-events API name
```

#### Additional documentation 

n/a