### PR TITLE
CloudEvent local wrapper renaming

### DIFF
--- a/code/API_definitions/webrtc-events-subscriptions.yaml
+++ b/code/API_definitions/webrtc-events-subscriptions.yaml
@@ -274,7 +274,7 @@ paths:
                 content:
                   application/cloudevents+json:
                     schema:
-                      $ref: "#/components/schemas/CloudEvent"
+                      $ref: "#/components/schemas/WebrtcEventNotification"
                     examples:
                       NEW_SESSION_INCOMING (session-invitation):
                         $ref: "#/components/examples/NEW_SESSION_INCOMING"
@@ -841,7 +841,7 @@ components:
       description: The unique identifier of the WebRTC registration.
       example: ln3C-ttOSk-ObcQ7A0-tYO1LXqy
 
-    CloudEvent:
+    WebrtcEventNotification:
       description: The notification callback
       allOf:
         - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent"
@@ -870,7 +870,7 @@ components:
         contextualize (call subject, branding info, etc). It MUST include a mediaSessionId, to allow the
         endpoint to subscribe to this new call session.
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/WebrtcEventNotification"
         - type: object
           required:
             - data
@@ -892,7 +892,7 @@ components:
 
         Most common use is for SDP updates and signaling updates regarding call status.
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/WebrtcEventNotification"
         - type: object
           required:
             - data
@@ -1015,7 +1015,7 @@ components:
     EventSubscriptionEnded:
       description: event structure for event subscription ends
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/WebrtcEventNotification"
         - type: object
           properties:
             data:
@@ -1059,7 +1059,7 @@ components:
     EventRegistrationEnds:
       description: event structure for event subscription ends
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/WebrtcEventNotification"
         - type: object
           required:
             - data

--- a/code/API_definitions/webrtc-registration.yaml
+++ b/code/API_definitions/webrtc-registration.yaml
@@ -150,7 +150,7 @@ paths:
         guaranteed to be globally unique, the same `deviceId` value may be
         shared across registrations bound to different `phoneNumber`s. Only
         the registrations bound to a `phoneNumber` authorized by the access
-        token are returned; registrations bound to any other `phoneNumber
+        token are returned; registrations bound to any other `phoneNumber`
         are not included in the response.
 
         Returns an empty array if no active registrations exist for the


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug

#### What this PR does / why we need it:

Renames the local CloudEvent wrapper schema in webrtc-events-subscriptions.yaml to WebrtcEventNotification (5 refs updated), so the bundled release keeps exactly one CloudEvent schema — the shared Commonalities envelope — instead of the bundler auto-renaming it to CloudEvent-2 due to a name collision. Also fixes an unclosed-backtick typo in webrtc-registration.yaml.

#### Which issue(s) this PR fixes:

Fixes #211 
Fixes #199 

#### Special notes for reviewers:

Cross-file $ref to ../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent is untouched — only the local, API-specific discriminator wrapper is renamed. No behavior change; schema structure and discriminator mapping are identical.

This renaming invalidates the issue #199 as it's originated by this `CloudEvent-2` invalid renaming.

#### Changelog input

```
 release-note
fix(webrtc-events-subscriptions): Renamed local wrapper event object to WebrtcEventNotification
fix(webrtc-registration): Fix typo 
```

#### Additional documentation 

n/a